### PR TITLE
GitHub Pages Scaffolding

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,1 @@
+remote_theme: pmarsceill/just-the-docs

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,3 @@
+# Welcome to the Carbon Platform developer docs!
+
+This is where developer docs will go


### PR DESCRIPTION
Basic setup to create a github pages site based on the docs folder.

Using the "just the docs" theme, which has some basic search functionality