### PR TITLE
chore: add script to lint and fix in one go

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "packages:build": "npm --workspaces --if-present run package:build",
     "services:build": "npm --workspaces --if-present run service:build",
     "lint": "scripts/lint",
+    "lint:fix": "scripts/lint_and_fix",
     "nightly": "scripts/nightly",
     "prepare": "husky install"
   },

--- a/scripts/lint_and_fix
+++ b/scripts/lint_and_fix
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -e
+
+prettier --check --write .
+
+stylelint --fix '**/*.{css,scss,js,jsx,ts,tsx}'
+
+eslint --fix --ext .js,.jsx,.ts,.tsx .


### PR DESCRIPTION
Adds a script that runs all linters and fixes all [fixable] errors across all analyzed files.