### PR TITLE
feat: add external docs url to schemas

### DIFF
--- a/docs/resource-schemas.md
+++ b/docs/resource-schemas.md
@@ -31,6 +31,7 @@ description: React implementation of Carbon Components.
 | `name`            | Library display name. Use title-case capitalization.                                                                           | Required | String | –               | –            |
 | `description`     | Library description ideally between 50-160 characters in length. Use sentence-case capitalization.                             | Required | String | –               | –            |
 | `packageJsonPath` | Relative location of the library's `package.json`. This is used to reference the library's license, version, and code package. | Optional | String | `/package.json` | –            |
+| `externalDocsUrl` | Absolute URL to externally-hosted documentation.                                                                               | Optional | String | –               | –            |
 
 ## Asset schema
 
@@ -54,15 +55,16 @@ platform: web
 
 ### Asset keys
 
-| Key             | Description                                                                                                                     | Required | Type   | Default       | Valid values                                                                                   |
-| --------------- | ------------------------------------------------------------------------------------------------------------------------------- | -------- | ------ | ------------- | ---------------------------------------------------------------------------------------------- |
-| `name`          | Asset display name. Use sentence-case capitalization. All asset names in a library should be unique to prevent page collisions. | Required | String | –             | –                                                                                              |
-| `description`   | Asset description ideally between 50-160 characters in length. Use sentence-case capitalization.                                | Required | String | –             | –                                                                                              |
-| `thumbnailPath` | Relative location of the asset's thumbnail image.                                                                               | Optional | String | –             | –                                                                                              |
-| `status`        | Used to set consumption exptectations.                                                                                          | Required | String | `draft`       | `draft`, `experimental`, `stable`, `deprecated`, `sunset`                                      |
-| `type`          | Asset categorization.                                                                                                           | Required | String | –             | `element`, `component`, `pattern`, `function`, `layout`                                        |
-| `framework`     | Asset frontend framework.                                                                                                       | Required | String | `design-only` | `angular`, `react`, `react-native`, `svelte`, `vanilla`, `vue`, `web-component`, `design-only` |
-| `platform`      | Asset environment.                                                                                                              | Required | String | `web`         | `cross-platform`, `web`                                                                        |
+| Key               | Description                                                                                                                     | Required | Type   | Default       | Valid values                                                                                   |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------- | -------- | ------ | ------------- | ---------------------------------------------------------------------------------------------- |
+| `name`            | Asset display name. Use sentence-case capitalization. All asset names in a library should be unique to prevent page collisions. | Required | String | –             | –                                                                                              |
+| `description`     | Asset description ideally between 50-160 characters in length. Use sentence-case capitalization.                                | Required | String | –             | –                                                                                              |
+| `thumbnailPath`   | Relative location of the asset's thumbnail image.                                                                               | Optional | String | –             | –                                                                                              |
+| `externalDocsUrl` | Absolute URL to externally-hosted documentation.                                                                                | Optional | String | –             | –                                                                                              |
+| `status`          | Used to set consumption exptectations.                                                                                          | Required | String | `draft`       | `draft`, `experimental`, `stable`, `deprecated`, `sunset`                                      |
+| `type`            | Asset categorization.                                                                                                           | Required | String | –             | `element`, `component`, `pattern`, `function`, `layout`                                        |
+| `framework`       | Asset frontend framework.                                                                                                       | Required | String | `design-only` | `angular`, `react`, `react-native`, `svelte`, `vanilla`, `vue`, `web-component`, `design-only` |
+| `platform`        | Asset environment.                                                                                                              | Required | String | `web`         | `cross-platform`, `web`                                                                        |
 
 #### Asset status
 

--- a/services/web-app/pages/assets/components.js
+++ b/services/web-app/pages/assets/components.js
@@ -34,7 +34,7 @@ const Components = ({ librariesData }) => {
   )
 }
 
-export const getServerSideProps = async () => {
+export const getStaticProps = async () => {
   const librariesData = await getAllLibraries()
 
   return {

--- a/services/web-app/pages/assets/elements.js
+++ b/services/web-app/pages/assets/elements.js
@@ -34,7 +34,7 @@ const Elements = ({ librariesData }) => {
   )
 }
 
-export const getServerSideProps = async () => {
+export const getStaticProps = async () => {
   const librariesData = await getAllLibraries()
 
   return {

--- a/services/web-app/pages/assets/libraries.js
+++ b/services/web-app/pages/assets/libraries.js
@@ -46,7 +46,7 @@ const Libraries = ({ librariesData }) => {
   )
 }
 
-export const getServerSideProps = async () => {
+export const getStaticProps = async () => {
   const librariesData = await getAllLibraries()
 
   return {

--- a/services/web-app/pages/assets/patterns.js
+++ b/services/web-app/pages/assets/patterns.js
@@ -34,7 +34,7 @@ const Patterns = ({ librariesData }) => {
   )
 }
 
-export const getServerSideProps = async () => {
+export const getStaticProps = async () => {
   const librariesData = await getAllLibraries()
 
   return {

--- a/services/web-app/pages/index.js
+++ b/services/web-app/pages/index.js
@@ -9,7 +9,6 @@ import { useContext, useEffect } from 'react'
 
 import { LayoutContext } from '@/layouts/layout'
 import { NextSeo } from 'next-seo'
-import { Svg16Carbon } from '@carbon-platform/icons'
 import defaultSeo from '@/config/seo.json'
 
 const navData = [
@@ -35,7 +34,6 @@ const Index = () => {
     <>
       <NextSeo {...seo} />
       Home
-      <Svg16Carbon style={{ color: '#ffc0cb' }} />
     </>
   )
 }


### PR DESCRIPTION
Adds external docs URL to schemas.

#### Changelog

**New**

- `externalDocsUrl` to library and asset schemas for when we index content that we won't initially host (e.g. PAL sites)

**Changed**

- Catalog pages are now statically generated. There is no advantage for them being SSG at the moment. All libraries (and assets) are fetched and cached upon visiting any given catalog page.