### PR TITLE
chore: index monorepo libraries

### DIFF
--- a/services/web-app/data/libraries.js
+++ b/services/web-app/data/libraries.js
@@ -94,6 +94,12 @@ const libraryAllowList = {
     repo: 'carbon',
     path: '/packages/motion'
   },
+  'carbon-patterns': {
+    host: 'github.ibm.com',
+    org: 'matt-rosno',
+    repo: 'carbon',
+    path: '/packages/patterns'
+  },
   'carbon-pictograms': {
     host: 'github.ibm.com',
     org: 'matt-rosno',

--- a/services/web-app/data/libraries.js
+++ b/services/web-app/data/libraries.js
@@ -14,7 +14,115 @@ const libraryAllowList = {
     host: 'github.ibm.com',
     org: 'matt-rosno',
     repo: 'carbon',
-    path: '/packages/react'
+    path: '/packages/carbon-react'
+  },
+  'carbon-cli': {
+    host: 'github.ibm.com',
+    org: 'matt-rosno',
+    repo: 'carbon',
+    path: '/packages/cli'
+  },
+  'carbon-cli-reporter': {
+    host: 'github.ibm.com',
+    org: 'matt-rosno',
+    repo: 'carbon',
+    path: '/packages/cli-reporter'
+  },
+  'carbon-colors': {
+    host: 'github.ibm.com',
+    org: 'matt-rosno',
+    repo: 'carbon',
+    path: '/packages/colors'
+  },
+  'carbon-components': {
+    host: 'github.ibm.com',
+    org: 'matt-rosno',
+    repo: 'carbon',
+    path: '/packages/components'
+  },
+  'carbon-elements': {
+    host: 'github.ibm.com',
+    org: 'matt-rosno',
+    repo: 'carbon',
+    path: '/packages/elements'
+  },
+  'carbon-feature-flags': {
+    host: 'github.ibm.com',
+    org: 'matt-rosno',
+    repo: 'carbon',
+    path: '/packages/feature-flags'
+  },
+  'carbon-grid': {
+    host: 'github.ibm.com',
+    org: 'matt-rosno',
+    repo: 'carbon',
+    path: '/packages/grid'
+  },
+  'carbon-icons': {
+    host: 'github.ibm.com',
+    org: 'matt-rosno',
+    repo: 'carbon',
+    path: '/packages/icons'
+  },
+  'carbon-icons-handlebars': {
+    host: 'github.ibm.com',
+    org: 'matt-rosno',
+    repo: 'carbon',
+    path: '/packages/icons-handlebars'
+  },
+  'carbon-icons-react': {
+    host: 'github.ibm.com',
+    org: 'matt-rosno',
+    repo: 'carbon',
+    path: '/packages/icons-react'
+  },
+  'carbon-icons-vue': {
+    host: 'github.ibm.com',
+    org: 'matt-rosno',
+    repo: 'carbon',
+    path: '/packages/icons-vue'
+  },
+  'carbon-layout': {
+    host: 'github.ibm.com',
+    org: 'matt-rosno',
+    repo: 'carbon',
+    path: '/packages/layout'
+  },
+  'carbon-motion': {
+    host: 'github.ibm.com',
+    org: 'matt-rosno',
+    repo: 'carbon',
+    path: '/packages/motion'
+  },
+  'carbon-pictograms': {
+    host: 'github.ibm.com',
+    org: 'matt-rosno',
+    repo: 'carbon',
+    path: '/packages/pictograms'
+  },
+  'carbon-pictograms-react': {
+    host: 'github.ibm.com',
+    org: 'matt-rosno',
+    repo: 'carbon',
+    path: '/packages/pictograms-react'
+  },
+  'carbon-themes': {
+    host: 'github.ibm.com',
+    org: 'matt-rosno',
+    repo: 'carbon',
+    path: '/packages/themes'
+  },
+  'carbon-type': {
+    host: 'github.ibm.com',
+    org: 'matt-rosno',
+    repo: 'carbon',
+    path: '/packages/type'
+  },
+  'carbon-upgrade': {
+    host: 'github.ibm.com',
+    org: 'matt-rosno',
+    repo: 'carbon',
+    path: '/packages/upgrade'
   }
 }
 

--- a/services/web-app/pages/assets/libraries.js
+++ b/services/web-app/pages/assets/libraries.js
@@ -37,6 +37,9 @@ const Libraries = ({ librariesData }) => {
             <Link href={`/assets/${library.params.slug}`}>
               <a>{library.content.name}</a>
             </Link>
+            <ul className={styles.bullets}>
+              <li className={styles.bulletsItem}>{library.content.description}</li>
+            </ul>
           </li>
         ))}
       </ul>

--- a/services/web-app/pages/pages.module.scss
+++ b/services/web-app/pages/pages.module.scss
@@ -8,3 +8,11 @@
 .data {
   @include type-style('code-01');
 }
+
+.bullets {
+  list-style-type: initial;
+}
+
+.bullets-item {
+  margin-left: 20px;
+}


### PR DESCRIPTION
Related #16 

Indexes all non-private libraries from Carbon's monorepo and includes assets currently in Carbon website's side nav.

#### Changelog

**New**

- Bulleted descriptions in the `/assets/libraries` catalog
