### PR TITLE
feat: add sponsor team to each library

### DIFF
--- a/services/web-app/data/libraries.js
+++ b/services/web-app/data/libraries.js
@@ -14,151 +14,176 @@ const libraryAllowList = {
     host: 'github.ibm.com',
     org: 'matt-rosno',
     repo: 'carbon',
-    path: '/packages/carbon-react'
+    path: '/packages/carbon-react',
+    sponsor: 'carbon'
   },
   'carbon-cli': {
     host: 'github.ibm.com',
     org: 'matt-rosno',
     repo: 'carbon',
-    path: '/packages/cli'
+    path: '/packages/cli',
+    sponsor: 'carbon'
   },
   'carbon-cli-reporter': {
     host: 'github.ibm.com',
     org: 'matt-rosno',
     repo: 'carbon',
-    path: '/packages/cli-reporter'
+    path: '/packages/cli-reporter',
+    sponsor: 'carbon'
   },
   'carbon-colors': {
     host: 'github.ibm.com',
     org: 'matt-rosno',
     repo: 'carbon',
-    path: '/packages/colors'
+    path: '/packages/colors',
+    sponsor: 'carbon'
   },
   'carbon-components': {
     host: 'github.ibm.com',
     org: 'matt-rosno',
     repo: 'carbon',
-    path: '/packages/components'
+    path: '/packages/components',
+    sponsor: 'carbon'
   },
   'carbon-elements': {
     host: 'github.ibm.com',
     org: 'matt-rosno',
     repo: 'carbon',
-    path: '/packages/elements'
+    path: '/packages/elements',
+    sponsor: 'carbon'
   },
   'carbon-feature-flags': {
     host: 'github.ibm.com',
     org: 'matt-rosno',
     repo: 'carbon',
-    path: '/packages/feature-flags'
+    path: '/packages/feature-flags',
+    sponsor: 'carbon'
   },
   'carbon-grid': {
     host: 'github.ibm.com',
     org: 'matt-rosno',
     repo: 'carbon',
-    path: '/packages/grid'
+    path: '/packages/grid',
+    sponsor: 'carbon'
   },
   'carbon-icons': {
     host: 'github.ibm.com',
     org: 'matt-rosno',
     repo: 'carbon',
-    path: '/packages/icons'
+    path: '/packages/icons',
+    sponsor: 'carbon'
   },
   'carbon-icons-handlebars': {
     host: 'github.ibm.com',
     org: 'matt-rosno',
     repo: 'carbon',
-    path: '/packages/icons-handlebars'
+    path: '/packages/icons-handlebars',
+    sponsor: 'carbon'
   },
   'carbon-icons-react': {
     host: 'github.ibm.com',
     org: 'matt-rosno',
     repo: 'carbon',
-    path: '/packages/icons-react'
+    path: '/packages/icons-react',
+    sponsor: 'carbon'
   },
   'carbon-icons-vue': {
     host: 'github.ibm.com',
     org: 'matt-rosno',
     repo: 'carbon',
-    path: '/packages/icons-vue'
+    path: '/packages/icons-vue',
+    sponsor: 'carbon'
   },
   'carbon-layout': {
     host: 'github.ibm.com',
     org: 'matt-rosno',
     repo: 'carbon',
-    path: '/packages/layout'
+    path: '/packages/layout',
+    sponsor: 'carbon'
   },
   'carbon-motion': {
     host: 'github.ibm.com',
     org: 'matt-rosno',
     repo: 'carbon',
-    path: '/packages/motion'
+    path: '/packages/motion',
+    sponsor: 'carbon'
   },
   'carbon-patterns': {
     host: 'github.ibm.com',
     org: 'matt-rosno',
     repo: 'carbon',
-    path: '/packages/patterns'
+    path: '/packages/patterns',
+    sponsor: 'carbon'
   },
   'carbon-pictograms': {
     host: 'github.ibm.com',
     org: 'matt-rosno',
     repo: 'carbon',
-    path: '/packages/pictograms'
+    path: '/packages/pictograms',
+    sponsor: 'carbon'
   },
   'carbon-pictograms-react': {
     host: 'github.ibm.com',
     org: 'matt-rosno',
     repo: 'carbon',
-    path: '/packages/pictograms-react'
+    path: '/packages/pictograms-react',
+    sponsor: 'carbon'
   },
   'carbon-themes': {
     host: 'github.ibm.com',
     org: 'matt-rosno',
     repo: 'carbon',
-    path: '/packages/themes'
+    path: '/packages/themes',
+    sponsor: 'carbon'
   },
   'carbon-type': {
     host: 'github.ibm.com',
     org: 'matt-rosno',
     repo: 'carbon',
-    path: '/packages/type'
+    path: '/packages/type',
+    sponsor: 'carbon'
   },
   'carbon-upgrade': {
     host: 'github.ibm.com',
     org: 'matt-rosno',
     repo: 'carbon',
-    path: '/packages/upgrade'
+    path: '/packages/upgrade',
+    sponsor: 'carbon'
   },
   'ibmdotcom-react': {
     host: 'github.ibm.com',
     org: 'matt-rosno',
     repo: 'carbon-for-ibm-dotcom',
-    path: '/packages/react'
+    path: '/packages/react',
+    sponsor: 'ibm-dotcom'
   },
   'ibmdotcom-web-components': {
     host: 'github.ibm.com',
     org: 'matt-rosno',
     repo: 'carbon-for-ibm-dotcom',
-    path: '/packages/web-components'
+    path: '/packages/web-components',
+    sponsor: 'ibm-dotcom'
   },
   'ibmdotcom-services': {
     host: 'github.ibm.com',
     org: 'matt-rosno',
     repo: 'carbon-for-ibm-dotcom',
-    path: '/packages/services'
+    path: '/packages/services',
+    sponsor: 'ibm-dotcom'
   },
   'ibmdotcom-styles': {
     host: 'github.ibm.com',
     org: 'matt-rosno',
     repo: 'carbon-for-ibm-dotcom',
-    path: '/packages/styles'
+    path: '/packages/styles',
+    sponsor: 'ibm-dotcom'
   },
   'ibmdotcom-utilities': {
     host: 'github.ibm.com',
     org: 'matt-rosno',
     repo: 'carbon-for-ibm-dotcom',
-    path: '/packages/utilities'
+    path: '/packages/utilities',
+    sponsor: 'ibm-dotcom'
   }
 }
 

--- a/services/web-app/data/teams.js
+++ b/services/web-app/data/teams.js
@@ -11,7 +11,7 @@
  * specified as object keys to ensure uniqueness.
  *
  * TODO: either specify a path to a mark image here, or create a utility function to receive a team
- * slug and return the image to use in each catalog item. We'll need a placeholder icons for
+ * slug and return the image to use in each catalog item. We'll need a placeholder icon for
  * libraries that don't have a sponsor (e.g. Carbon Vanilla Components.)
  */
 export const teams = {

--- a/services/web-app/data/teams.js
+++ b/services/web-app/data/teams.js
@@ -11,7 +11,8 @@
  * specified as object keys to ensure uniqueness.
  *
  * TODO: either specify a path to a mark image here, or create a utility function to receive a team
- * slug and return the image to use in each catalog item.
+ * slug and return the image to use in each catalog item. We'll need a placeholder icons for
+ * libraries that don't have a sponsor (e.g. Carbon Vanilla Components.)
  */
 export const teams = {
   carbon: {

--- a/services/web-app/data/teams.js
+++ b/services/web-app/data/teams.js
@@ -1,0 +1,23 @@
+/*
+ * Copyright IBM Corp. 2021, 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Teams are defined here for now, but in the future we will probably want these stored in our data-
+ * base. Team keys are used in the libraries allowlist to specify sponsorship. Team slugs are
+ * specified as object keys to ensure uniqueness.
+ *
+ * TODO: either specify a path to a mark image here, or create a utility function to receive a team
+ * slug and return the image to use in each catalog item.
+ */
+export const teams = {
+  carbon: {
+    name: 'Carbon'
+  },
+  'ibm-dotcom': {
+    name: 'IBM.com'
+  }
+}


### PR DESCRIPTION
Related #6

Libraries can have a sponsor team. This is different than maintainers, which are individuals. It's likely that the majority of maintainers will belong to the sponsor team for any given library.

By specifying a sponsor team, we can show that in the catalogs that there is a group of IBMers, a team, committed to maintaining the library. By "sponsoring", we mean committing their time to act as the primary group of maintainers.

Each sponsor team will have a name and a "mark" (an icon). Instead of adding the sponsor team to each schema, because this is something that will likely be stored in our database, we can simply specify sponsor teams in the libraries allowlist.

See comment in `/data/teams.js` for how we can use this in the catalogs.

#### Changelog

**New**

- Adds initial data structure for sponsor teams that will grow as we index more libraries