### PR TITLE
feat: add private property to resource schemas

### DIFF
--- a/docs/resource-schemas.md
+++ b/docs/resource-schemas.md
@@ -26,12 +26,13 @@ description: React implementation of Carbon Components
 
 ### Library keys
 
-| Key               | Description                                                                                                                    | Required | Type   | Default         | Valid values |
-| ----------------- | ------------------------------------------------------------------------------------------------------------------------------ | -------- | ------ | --------------- | ------------ |
-| `name`            | Library display name. Use title-case capitalization.                                                                           | Required | String | –               | –            |
-| `description`     | Library description ideally between 50-160 characters in length. Use sentence-case capitalization.                             | Required | String | –               | –            |
-| `packageJsonPath` | Relative location of the library's `package.json`. This is used to reference the library's license, version, and code package. | Optional | String | `/package.json` | –            |
-| `externalDocsUrl` | Absolute URL to externally-hosted documentation.                                                                               | Optional | String | –               | –            |
+| Key               | Description                                                                                                                    | Required | Type    | Default         | Valid values |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------ | -------- | ------- | --------------- | ------------ |
+| `name`            | Library display name. Use title-case capitalization.                                                                           | Required | String  | –               | –            |
+| `description`     | Library description ideally between 50-160 characters in length. Use sentence-case capitalization.                             | Required | String  | –               | –            |
+| `packageJsonPath` | Relative location of the library's `package.json`. This is used to reference the library's license, version, and code package. | Optional | String  | `/package.json` | –            |
+| `externalDocsUrl` | Absolute URL to externally-hosted documentation.                                                                               | Optional | String  | –               | –            |
+| `private`         | If set to `true`, the catalogs will exclude the library.                                                                       | Optional | Boolean | `false`         | –            |
 
 ## Asset schema
 
@@ -55,16 +56,17 @@ platform: web
 
 ### Asset keys
 
-| Key               | Description                                                                                                                     | Required | Type   | Default       | Valid values                                                                                   |
-| ----------------- | ------------------------------------------------------------------------------------------------------------------------------- | -------- | ------ | ------------- | ---------------------------------------------------------------------------------------------- |
-| `name`            | Asset display name. Use sentence-case capitalization. All asset names in a library should be unique to prevent page collisions. | Required | String | –             | –                                                                                              |
-| `description`     | Asset description ideally between 50-160 characters in length. Use sentence-case capitalization.                                | Required | String | –             | –                                                                                              |
-| `thumbnailPath`   | Relative location of the asset's thumbnail image.                                                                               | Optional | String | –             | –                                                                                              |
-| `externalDocsUrl` | Absolute URL to externally-hosted documentation.                                                                                | Optional | String | –             | –                                                                                              |
-| `status`          | Used to set consumption exptectations.                                                                                          | Required | String | `draft`       | `draft`, `experimental`, `stable`, `deprecated`, `sunset`                                      |
-| `type`            | Asset categorization.                                                                                                           | Required | String | –             | `element`, `component`, `pattern`, `function`, `layout`                                        |
-| `framework`       | Asset frontend framework.                                                                                                       | Required | String | `design-only` | `angular`, `react`, `react-native`, `svelte`, `vanilla`, `vue`, `web-component`, `design-only` |
-| `platform`        | Asset environment.                                                                                                              | Required | String | `web`         | `cross-platform`, `web`                                                                        |
+| Key               | Description                                                                                                                     | Required | Type    | Default       | Valid values                                                                                   |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------- | -------- | ------- | ------------- | ---------------------------------------------------------------------------------------------- |
+| `name`            | Asset display name. Use sentence-case capitalization. All asset names in a library should be unique to prevent page collisions. | Required | String  | –             | –                                                                                              |
+| `description`     | Asset description ideally between 50-160 characters in length. Use sentence-case capitalization.                                | Required | String  | –             | –                                                                                              |
+| `thumbnailPath`   | Relative location of the asset's thumbnail image.                                                                               | Optional | String  | –             | –                                                                                              |
+| `externalDocsUrl` | Absolute URL to externally-hosted documentation.                                                                                | Optional | String  | –             | –                                                                                              |
+| `status`          | Used to set consumption exptectations.                                                                                          | Required | String  | `draft`       | `draft`, `experimental`, `stable`, `deprecated`, `sunset`                                      |
+| `type`            | Asset categorization.                                                                                                           | Required | String  | –             | `element`, `component`, `pattern`, `function`, `layout`                                        |
+| `framework`       | Asset frontend framework.                                                                                                       | Required | String  | `design-only` | `angular`, `react`, `react-native`, `svelte`, `vanilla`, `vue`, `web-component`, `design-only` |
+| `platform`        | Asset environment.                                                                                                              | Required | String  | `web`         | `cross-platform`, `web`                                                                        |
+| `private`         | If set to `true`, the catalogs will exclude the asset.                                                                          | Optional | Boolean | `false`       | –                                                                                              |
 
 #### Asset status
 

--- a/services/web-app/components/catalog-index-page/catalog-index-page.js
+++ b/services/web-app/components/catalog-index-page/catalog-index-page.js
@@ -22,7 +22,7 @@ const CatalogIndexPage = ({ data, type = 'component' }) => {
     .reduce((assets, library) => {
       return assets.concat(library.assets)
     }, [])
-    .filter((asset) => asset.content.type === type)
+    .filter((asset) => !asset.content.private && asset.content.type === type)
     .sort((a, b) =>
       a.content.name > b.content.name ? 1 : b.content.name > a.content.name ? -1 : 0
     )

--- a/services/web-app/lib/github.js
+++ b/services/web-app/lib/github.js
@@ -92,7 +92,10 @@ export const getLibraryData = async (params = {}) => {
   return {
     params: libraryParams,
     response,
-    content,
+    content: {
+      ...content,
+      private: !!content.private // default to false if not specified
+    },
     assets: filteredAssets
   }
 }
@@ -150,7 +153,10 @@ export const getLibraryAssets = async (params = {}) => {
     return {
       params: libraryParams,
       response,
-      content
+      content: {
+        ...content,
+        private: !!content.private // default to false if not specified
+      }
     }
   })
 

--- a/services/web-app/pages/assets/libraries.js
+++ b/services/web-app/pages/assets/libraries.js
@@ -24,9 +24,11 @@ const Libraries = ({ librariesData }) => {
     setNavData(assetsNavData)
   }, [setNavData])
 
-  const libraries = librariesData.libraries.sort((a, b) =>
-    a.content.name > b.content.name ? 1 : b.content.name > a.content.name ? -1 : 0
-  )
+  const libraries = librariesData.libraries
+    .filter((library) => !library.content.private)
+    .sort((a, b) =>
+      a.content.name > b.content.name ? 1 : b.content.name > a.content.name ? -1 : 0
+    )
 
   return (
     <>


### PR DESCRIPTION
Related #6 

Adds an option to exclude libraries and assets for the catalogs. By default, all indexed libraries and assets will be included in the catalogs. This follows how npm uses the `private` key. See: https://docs.npmjs.com/cli/v7/configuring-npm/package-json#private

In the future, we'll have some "reviewed" or "verified" property that will be used in the catalog's default filters. To counter-balance `private` which defaults to showing everything, `reviewed` will default to not reviewed so the resource can go through the review process.

#### Changelog

**New**

- `private` key in the schemas, defaulting to false
- Library and asset catalog pages filter out private items

#### Testing / reviewing

See docs file that explains the `private` key.
