### PR TITLE
fix: dont generate placeholder images for now

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16430,7 +16430,7 @@
         "css-loader": "^6.4.0",
         "fs-extra": "^10.0.0",
         "js-yaml": "^4.1.0",
-        "lodash": "*",
+        "lodash": "^4.17.21",
         "next": "^12.0.2",
         "next-seo": "^4.28.1",
         "plaiceholder": "^2.2.0",

--- a/services/web-app/lib/github.js
+++ b/services/web-app/lib/github.js
@@ -226,7 +226,8 @@ const getLibraryAssets = async (params = {}, inheritContent = false) => {
 
   const inheritedAssets = inheritContent ? await getInheritedAssets(assets) : []
 
-  const imgPlaceholders = await getImagePlaceholders(assets)
+  // TODO this is commented out to prevent production build errors
+  const imgPlaceholders = [] // await getImagePlaceholders(assets)
 
   return assets.map((asset) => {
     const assetExtensions = getAssetExtensions(asset, inheritedAssets, imgPlaceholders)
@@ -337,6 +338,7 @@ const getInheritedAssets = async (assets) => {
  * @param {import('../typedefs').Asset[]} assets - Assets
  * @returns {Promise<import('../typedefs').PlaceholderImage[]>} Array of placeholder objects
  */
+// eslint-disable-next-line no-unused-vars
 const getImagePlaceholders = async (assets) => {
   // find all thumbnail images, get content of each image, filter out assets with no thumbnail
 


### PR DESCRIPTION
Closes #132 

There's some production build-time race condition where images don't sit on disk prior to our attempt to generate placeholder images. Because the images can't work in production anyway (#68), the best thing to do right now is not even attempt to generate the placeholder images for now.