### PR TITLE
chore: update stylelint rules and update hover borders on catalog

### DIFF
--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -4,6 +4,13 @@ module.exports = {
   reportNeedlessDisables: true,
   reportInvalidScopeDisables: true,
   rules: {
-    'selector-pseudo-class-no-unknown': null
+    'selector-pseudo-class-no-unknown': null,
+    'max-nesting-depth': [
+      1,
+      {
+        ignore: ['pseudo-classes'],
+        ignoreAtRules: ['include']
+      }
+    ]
   }
 }

--- a/services/web-app/components/catalog-item/catalog-item.js
+++ b/services/web-app/components/catalog-item/catalog-item.js
@@ -62,7 +62,7 @@ const CatalogItemContent = ({ asset, isGrid = false }) => {
         {sponsorName && <p className={styles.sponsor}>{sponsorName}</p>}
         {name && <p className={styles.name}>{name}</p>}
         {description && <p className={styles.description}>{description}</p>}
-        <div className={styles.icon}>
+        <div className={styles.icon} title={sponsorName && `Sponsored by ${sponsorName}`}>
           {SponsorIcon && <SponsorIcon className={styles.iconSponsor} size={24} />}
           {externalDocsUrl && <ArrowUpRight className={styles.iconExternal} size={24} />}
         </div>

--- a/services/web-app/components/catalog-item/catalog-item.module.scss
+++ b/services/web-app/components/catalog-item/catalog-item.module.scss
@@ -9,12 +9,18 @@
 
 .column {
   position: relative;
+  transition: border-color $fast-02 carbon--motion(standard, productive);
 }
 
 .column:not(:first-child) {
   @include breakpoint(md) {
     border-left: 1px solid $layer-accent;
   }
+}
+
+.anchor:hover .column,
+.anchor:focus .column {
+  border-color: $border-subtle-selected;
 }
 
 .column-image {
@@ -60,6 +66,12 @@
 .anchor--grid .content {
   border-top: 1px solid $layer-accent;
   margin-right: 0;
+  transition: border-color $fast-02 carbon--motion(standard, productive);
+}
+
+.anchor--grid:hover .content,
+.anchor--grid:focus .content {
+  border-color: $border-subtle-selected;
 }
 
 .sponsor {
@@ -102,7 +114,7 @@
   background: $background;
   border-radius: 100%;
   color: $icon-primary;
-  transition: background $fast-02 carbon--motion(standard, productive);
+  transition: all $fast-02 carbon--motion(standard, productive);
   @include breakpoint(xlg) {
     width: $spacing-09 + $spacing-03;
     height: $spacing-09 + $spacing-03;
@@ -152,6 +164,7 @@
 
 .anchor:hover .icon,
 .anchor:focus .icon {
+  border-color: $border-subtle-selected;
   background: $layer-hover;
 }
 
@@ -164,11 +177,17 @@
   position: absolute;
   top: $spacing-04;
   right: $spacing-04;
+  transition: background $fast-02 carbon--motion(standard, productive);
 }
 
 .anchor--grid .framework {
   top: auto;
   bottom: $spacing-04;
+}
+
+.anchor:hover .framework,
+.anchor:focus .framework {
+  background: $border-subtle-selected;
 }
 
 .meta {

--- a/services/web-app/components/catalog-item/catalog-item.module.scss
+++ b/services/web-app/components/catalog-item/catalog-item.module.scss
@@ -10,25 +10,25 @@
 .column {
   position: relative;
   transition: border-color $fast-02 carbon--motion(standard, productive);
-}
 
-.column:not(:first-child) {
-  @include breakpoint(md) {
-    border-left: 1px solid $layer-accent;
+  &:not(:first-child) {
+    @include breakpoint(md) {
+      border-left: 1px solid $layer-accent;
+    }
+
+    .anchor:hover &,
+    .anchor:focus & {
+      border-color: $border-subtle-selected;
+    }
   }
-}
 
-.anchor:hover .column,
-.anchor:focus .column {
-  border-color: $border-subtle-selected;
-}
-
-.column-image {
-  @include breakpoint-down(md) {
-    display: none;
-  }
-  @include breakpoint(md) {
-    margin-right: calc(#{-$spacing-05} + 1px);
+  &--image {
+    @include breakpoint-down(md) {
+      display: none;
+    }
+    @include breakpoint(md) {
+      margin-right: calc(#{-$spacing-05} + 1px);
+    }
   }
 }
 
@@ -37,22 +37,27 @@
   background: $background;
   text-decoration: none;
   transition: background $fast-02 carbon--motion(standard, productive);
-}
 
-.anchor:active {
-  outline: 2px solid $focus;
-  outline-offset: -2px;
-}
+  &:hover,
+  &:focus {
+    background: $layer-hover;
+  }
 
-.anchor--grid {
-  margin-top: $spacing-05;
-}
+  &:active {
+    outline: 2px solid $focus;
+    outline-offset: -2px;
+  }
 
-.anchor:not(.anchor--grid) {
-  border-top: 1px solid $layer-accent;
-  @include breakpoint(md) {
-    padding-left: $spacing-05;
-    margin-left: -$spacing-05;
+  &--grid {
+    margin-top: $spacing-05;
+  }
+
+  &:not(.anchor--grid) {
+    border-top: 1px solid $layer-accent;
+    @include breakpoint(md) {
+      padding-left: $spacing-05;
+      margin-left: -$spacing-05;
+    }
   }
 }
 
@@ -61,17 +66,17 @@
   @include breakpoint(lg) {
     padding-right: 0;
   }
-}
 
-.anchor--grid .content {
-  border-top: 1px solid $layer-accent;
-  margin-right: 0;
-  transition: border-color $fast-02 carbon--motion(standard, productive);
-}
+  .anchor--grid & {
+    border-top: 1px solid $layer-accent;
+    margin-right: 0;
+    transition: border-color $fast-02 carbon--motion(standard, productive);
+  }
 
-.anchor--grid:hover .content,
-.anchor--grid:focus .content {
-  border-color: $border-subtle-selected;
+  .anchor--grid:hover &,
+  .anchor--grid:focus & {
+    border-color: $border-subtle-selected;
+  }
 }
 
 .sponsor {
@@ -84,11 +89,11 @@
   color: $text-primary;
   @include line-clamp(2);
   @include type-style('productive-heading-02');
-}
 
-.anchor--grid .name {
-  @include breakpoint-down(xlg) {
-    @include line-clamp(1);
+  .anchor--grid & {
+    @include breakpoint-down(xlg) {
+      @include line-clamp(1);
+    }
   }
 }
 
@@ -97,10 +102,10 @@
   color: $text-primary;
   @include line-clamp(3);
   @include type-style('body-short-01');
-}
 
-.anchor--grid .description {
-  display: none;
+  .anchor--grid & {
+    display: none;
+  }
 }
 
 .icon {
@@ -119,13 +124,25 @@
     width: $spacing-09 + $spacing-03;
     height: $spacing-09 + $spacing-03;
   }
-}
 
-.anchor--grid .icon {
-  top: math.div(-$spacing-09, 2);
-  bottom: auto;
-  @include breakpoint(xlg) {
-    top: math.div(-$spacing-09 - $spacing-03, 2);
+  .anchor--grid & {
+    top: math.div(-$spacing-09, 2);
+    bottom: auto;
+    @include breakpoint(xlg) {
+      top: math.div(-$spacing-09 - $spacing-03, 2);
+    }
+  }
+
+  .anchor--sponsor &,
+  .anchor--external:hover &,
+  .anchor--external:focus & {
+    display: block;
+  }
+
+  .anchor:hover &,
+  .anchor:focus & {
+    border-color: $border-subtle-selected;
+    background: $layer-hover;
   }
 }
 
@@ -140,37 +157,20 @@
 
 .icon-sponsor {
   opacity: 1;
+
+  .anchor--external:hover &,
+  .anchor--external:focus & {
+    opacity: 0;
+  }
 }
 
 .icon-external {
   opacity: 0;
-}
 
-.anchor--sponsor .icon,
-.anchor--external:hover .icon,
-.anchor--external:focus .icon {
-  display: block;
-}
-
-.anchor--external:hover .icon-external,
-.anchor--external:focus .icon-external {
-  opacity: 1;
-}
-
-.anchor--external:hover .icon-sponsor,
-.anchor--external:focus .icon-sponsor {
-  opacity: 0;
-}
-
-.anchor:hover .icon,
-.anchor:focus .icon {
-  border-color: $border-subtle-selected;
-  background: $layer-hover;
-}
-
-.anchor:hover,
-.anchor:focus {
-  background: $layer-hover;
+  .anchor--external:hover &,
+  .anchor--external:focus & {
+    opacity: 1;
+  }
 }
 
 .framework {
@@ -178,36 +178,36 @@
   top: $spacing-04;
   right: $spacing-04;
   transition: background $fast-02 carbon--motion(standard, productive);
-}
 
-.anchor--grid .framework {
-  top: auto;
-  bottom: $spacing-04;
-}
+  .anchor--grid & {
+    top: auto;
+    bottom: $spacing-04;
+  }
 
-.anchor:hover .framework,
-.anchor:focus .framework {
-  background: $border-subtle-selected;
+  .anchor:hover &,
+  .anchor:focus & {
+    background: $border-subtle-selected;
+  }
 }
 
 .meta {
   margin-top: $spacing-02;
   color: $text-secondary;
   @include type-style('label-01');
-}
 
-.meta--absolute {
-  position: absolute;
-  bottom: $spacing-04;
-  left: $spacing-04;
+  &--absolute {
+    position: absolute;
+    bottom: $spacing-04;
+    left: $spacing-04;
+  }
 }
 
 .meta-item {
   display: inline;
-}
 
-.meta-item:not(:first-child) {
-  margin-left: $spacing-03;
+  &:not(:first-child) {
+    margin-left: $spacing-03;
+  }
 }
 
 .meta-icon {

--- a/services/web-app/components/catalog-search/catalog-search.module.scss
+++ b/services/web-app/components/catalog-search/catalog-search.module.scss
@@ -5,17 +5,21 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-.column:not(:last-child) {
-  @include breakpoint(md) {
-    margin-right: -$spacing-05;
+.column {
+  &:not(:last-child) {
+    @include breakpoint(md) {
+      margin-right: -$spacing-05;
+    }
+  }
+
+  &:not(:first-child) {
+    border-left: 1px solid $layer-accent;
   }
 }
 
-.column:not(:first-child) {
-  border-left: 1px solid $layer-accent;
-}
-
-// override carbon display
-.container :global(.cds--label) {
-  display: none;
+.container {
+  // override carbon display
+  :global(.cds--label) {
+    display: none;
+  }
 }

--- a/services/web-app/components/catalog-sort/catalog-sort.module.scss
+++ b/services/web-app/components/catalog-sort/catalog-sort.module.scss
@@ -11,54 +11,56 @@
 
 .column {
   background: $background;
-}
 
-.column:not(:last-child) {
-  @include breakpoint(lg) {
-    margin-right: -$spacing-05;
+  &:not(:last-child) {
+    @include breakpoint(lg) {
+      margin-right: -$spacing-05;
+    }
+  }
+
+  &:not(:first-child) {
+    border-left: 1px solid $layer-accent;
+  }
+
+  &--switcher {
+    text-align: right;
+    @include breakpoint-down(lg) {
+      display: none;
+    }
   }
 }
 
-.column:not(:first-child) {
-  border-left: 1px solid $layer-accent;
-}
-
-.column-switcher {
-  text-align: right;
-  @include breakpoint-down(lg) {
-    display: none;
-  }
-}
-
-// override carbon display, grid-gap
 .dropdown {
+  // override carbon display, grid-gap
   position: relative;
   display: flex;
   width: 100%;
   padding-left: $spacing-05;
   grid-gap: 0;
+
+  // overide carbon color
+  :global(.cds--label) {
+    color: $text-primary;
+  }
+
+  // overide carbon position, flex-grow
+  :global(.cds--dropdown) {
+    position: static;
+    flex-grow: 1;
+  }
+
+  // overide carbon max-width
+  :global(.cds--list-box__field),
+  :global(.cds--list-box__menu) {
+    max-width: none;
+  }
 }
 
-// overide carbon color
-.dropdown :global(.cds--label) {
-  color: $text-primary;
-}
-
-// overide carbon position, flex-grow
-.dropdown :global(.cds--dropdown) {
-  position: static;
-  flex-grow: 1;
-}
-
-// overide carbon max-width
-.dropdown :global(.cds--list-box__field),
-.dropdown :global(.cds--list-box__menu) {
-  max-width: none;
-}
-
-// override background
-.selected:not(:hover),
-.selected:not(:focus) {
-  background: var(--cds-layer-selected-inverse);
-  --cds-icon-primary: var(--cds-icon-inverse);
+.selected {
+  // override background
+  &:not(:hover),
+  &:not(:focus) {
+    background: var(--cds-layer-selected-inverse);
+    --cds-icon-primary: var(--cds-icon-inverse);
+  }
 }

--- a/services/web-app/components/catalog/catalog.module.scss
+++ b/services/web-app/components/catalog/catalog.module.scss
@@ -5,8 +5,8 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-// override carbon max-width and width
 .notification {
+  // override carbon max-width and width
   max-width: none;
   margin: $spacing-07 0;
 

--- a/services/web-app/components/framework-icon/framework-icon.js
+++ b/services/web-app/components/framework-icon/framework-icon.js
@@ -4,35 +4,20 @@
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import {
-  Svg16Angular,
-  Svg16Javascript,
-  Svg16React,
-  Svg16Svelte,
-  Svg16Vue,
-  Svg16WebComponent
-} from '@carbon-platform/icons'
+
 import clsx from 'clsx'
+
+import { framework as frameworkMap } from '@/data/framework'
 
 import styles from './framework-icon.module.scss'
 
-const frameworkMap = {
-  angular: Svg16Angular,
-  react: Svg16React,
-  'react-native': Svg16React,
-  svelte: Svg16Svelte,
-  vanilla: Svg16Javascript,
-  vue: Svg16Vue,
-  'web-component': Svg16WebComponent
-}
-
 const FrameworkIcon = ({ className, framework }) => {
-  const Icon = frameworkMap[framework]
+  const { icon: Icon, name } = frameworkMap[framework]
 
   if (!Icon) return null
 
   return (
-    <div className={clsx(styles.container, className)}>
+    <div className={clsx(styles.container, className)} title={name}>
       <Icon className={styles.icon} />
     </div>
   )

--- a/services/web-app/components/status-icon/status-icon.js
+++ b/services/web-app/components/status-icon/status-icon.js
@@ -11,7 +11,7 @@ import { status as statusMap } from '@/data/status'
 import styles from './status-icon.module.scss'
 
 const StatusIcon = ({ className, status }) => {
-  const { icon: Icon } = statusMap[status]
+  const { icon: Icon, name } = statusMap[status]
 
   if (!Icon) return null
 
@@ -22,7 +22,11 @@ const StatusIcon = ({ className, status }) => {
     [styles.iconDeprecated]: status === 'deprecated'
   })
 
-  return <Icon className={stylesIcon} size={16} />
+  return (
+    <span className={stylesIcon} title={name}>
+      <Icon size={16} />
+    </span>
+  )
 }
 
 export default StatusIcon

--- a/services/web-app/components/status-icon/status-icon.module.scss
+++ b/services/web-app/components/status-icon/status-icon.module.scss
@@ -9,20 +9,20 @@ $status-experimental: #8a3ffc;
 
 .icon {
   color: $icon-primary;
-}
 
-.icon--draft {
-  color: $text-helper;
-}
+  &--draft {
+    color: $text-helper;
+  }
 
-.icon--experimental {
-  color: $status-experimental;
-}
+  &--experimental {
+    color: $status-experimental;
+  }
 
-.icon--stable {
-  color: $support-success;
-}
+  &--stable {
+    color: $support-success;
+  }
 
-.icon--deprecated {
-  color: $support-error;
+  &--deprecated {
+    color: $support-error;
+  }
 }

--- a/services/web-app/data/framework.js
+++ b/services/web-app/data/framework.js
@@ -1,0 +1,46 @@
+/*
+ * Copyright IBM Corp. 2021, 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {
+  Svg16Angular,
+  Svg16Javascript,
+  Svg16React,
+  Svg16Svelte,
+  Svg16Vue,
+  Svg16WebComponent
+} from '@carbon-platform/icons'
+
+export const framework = {
+  angular: {
+    icon: Svg16Angular,
+    name: 'Angular'
+  },
+  react: {
+    icon: Svg16React,
+    name: 'React'
+  },
+  'react-native': {
+    icon: Svg16React,
+    name: 'React Native'
+  },
+  svelte: {
+    icon: Svg16Svelte,
+    name: 'Svelte'
+  },
+  vanilla: {
+    icon: Svg16Javascript,
+    name: 'Vanilla JavaScript'
+  },
+  vue: {
+    icon: Svg16Vue,
+    name: 'Vue'
+  },
+  'web-component': {
+    icon: Svg16WebComponent,
+    name: 'Web Component'
+  }
+}

--- a/services/web-app/styles/_mixins.scss
+++ b/services/web-app/styles/_mixins.scss
@@ -1,3 +1,10 @@
+//
+// Copyright IBM Corp. 2021, 2021
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
 @mixin line-clamp($lines: 2) {
   display: -webkit-box;
   overflow: hidden;

--- a/services/web-app/styles/vendor/_overrides.scss
+++ b/services/web-app/styles/vendor/_overrides.scss
@@ -1,3 +1,10 @@
+//
+// Copyright IBM Corp. 2021, 2021
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
 .cds--content {
   margin-top: 3rem;
 }


### PR DESCRIPTION
#### Changelog

**New**

- Adds `title` attributes to sponsor icon, framework icon, and status icon. We can't use a tooltip here because it's containing anchor is interactive; the icons aren't interactive.
- New `framework` data object so we can use display names.
- Adds contextual subtle select border colors when catalog items are hovered and focused with transitions.

**Changed**

- Stylelint rules so we can have one level nesting and so mixins and pseudo state declaration blocks aren't counted
- Refactored component styles with nesting so the stylesheets are more legible

**Removed**

- N/A

#### Testing / reviewing

Component catalog should look exactly as it did before with darker borders on catalog item hover/focus.
