### PR TITLE
feat: upgrade carbon react to 0.11.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16168,7 +16168,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@carbon-platform/icons": "0.0.9",
-        "@carbon/react": "^0.8.0",
+        "@carbon/react": "^0.11.0",
         "@octokit/core": "^3.5.1",
         "cache-manager": "^3.6.0",
         "cache-manager-fs-hash": "^1.0.0",
@@ -16713,7 +16713,7 @@
       "version": "file:services/web-app",
       "requires": {
         "@carbon-platform/icons": "0.0.9",
-        "@carbon/react": "^0.8.0",
+        "@carbon/react": "0.11.0",
         "@octokit/core": "^3.5.1",
         "cache-manager": "^3.6.0",
         "cache-manager-fs-hash": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -717,9 +717,9 @@
       "integrity": "sha512-jvDUKz3NLopiDf7BROLDAT4NoswMpeXg4+ulbkLlFHdgY3v7gaxT/MJ7f9DZeEIiYUBhQSjTmcB3agIIO1jOdw=="
     },
     "node_modules/@carbon/icons-react": {
-      "version": "10.43.0",
-      "resolved": "https://registry.npmjs.org/@carbon/icons-react/-/icons-react-10.43.0.tgz",
-      "integrity": "sha512-BtRX3/wMqH3BrP1O32CKwz2DmuE351NVkk0gYuASIfDBOOf4BsZ30hBo7p6rUJ3JdjG0wXzbJgXD2XbvvHQIYw==",
+      "version": "10.44.0",
+      "resolved": "https://registry.npmjs.org/@carbon/icons-react/-/icons-react-10.44.0.tgz",
+      "integrity": "sha512-1M8J0/vMHYj5Bd4GmgkMP+tCsAD1gRCoiZYHNhohJb6ed40c2yaLa7DQ89PLStocZR9ZNtvc3akR00Ro3uiNWA==",
       "hasInstallScript": true,
       "dependencies": {
         "@carbon/icon-helpers": "^10.25.0",
@@ -746,17 +746,17 @@
       "integrity": "sha512-xNkDoRBfNsTKsUR0Hk7FItcdCDH7Mrn0mwvV83C8srV0M4x1D9Uh6Mg7pO9YLbUDMNEmihYp5u4Lf9zJv+XEVg=="
     },
     "node_modules/@carbon/react": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/@carbon/react/-/react-0.8.2.tgz",
-      "integrity": "sha512-rx9oxKhdqOWJdSvZzMEYJGJs1tX7KrTVafuME4aMfLSbiZPFziWNmac6jjdaVZy9lErxIN+9gYkFCCYjoL5z0A==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@carbon/react/-/react-0.11.0.tgz",
+      "integrity": "sha512-yaee2EU0AhtW1y/kioptvETRG3CwWkoo3l/BMMqrTp8/f4zwquIzzGQNtHXsjRxoqRM/By7wskiyuhXEnN2wpA==",
       "hasInstallScript": true,
       "dependencies": {
         "@carbon/feature-flags": "^0.6.0",
-        "@carbon/icons-react": "^10.42.0",
-        "@carbon/styles": "^0.8.0",
+        "@carbon/icons-react": "^10.44.0",
+        "@carbon/styles": "^0.11.0",
         "@carbon/telemetry": "0.0.0-alpha.6",
-        "carbon-components": "^10.47.1",
-        "carbon-components-react": "^7.47.2",
+        "carbon-components": "^10.50.0",
+        "carbon-components-react": "^7.50.0",
         "carbon-icons": "^7.0.7"
       },
       "peerDependencies": {
@@ -766,17 +766,17 @@
       }
     },
     "node_modules/@carbon/styles": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@carbon/styles/-/styles-0.8.0.tgz",
-      "integrity": "sha512-lykAX92/lTJ7mn7gkO0ykDbJtM+/DeOVyxnTfI0FXjBWyxgKAQ6abch7RKau80H3eVQSVxm+5Hsyj7C+v7cDjQ==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@carbon/styles/-/styles-0.11.0.tgz",
+      "integrity": "sha512-R2NyAellW3WtOaCsWaE8cBOJAl1gXqVJNcPYJSNp+eq2aFpWWyqrpYdMSG2ptUQrUbjPyz2IlP5iQIWI/10gBg==",
       "dependencies": {
         "@carbon/colors": "^10.34.0",
         "@carbon/feature-flags": "^0.6.0",
         "@carbon/grid": "^10.39.0",
         "@carbon/layout": "^10.34.0",
         "@carbon/motion": "^10.26.0",
-        "@carbon/themes": "^10.46.0",
-        "@carbon/type": "^10.38.0",
+        "@carbon/themes": "^10.48.0",
+        "@carbon/type": "^10.39.0",
         "@ibm/plex": "6.0.0-next.6"
       }
     },
@@ -858,20 +858,20 @@
       }
     },
     "node_modules/@carbon/themes": {
-      "version": "10.47.0",
-      "resolved": "https://registry.npmjs.org/@carbon/themes/-/themes-10.47.0.tgz",
-      "integrity": "sha512-/HDFq5JeQbxADhV8yCcNpTN2sNMlgTjaEBtgPDdmLlqU2hj5cl7NwHXGcixVfZa9Kp+Nha+njx9+shM19nd7ag==",
+      "version": "10.48.0",
+      "resolved": "https://registry.npmjs.org/@carbon/themes/-/themes-10.48.0.tgz",
+      "integrity": "sha512-g0dqvWQHPwWW1y+BSuu5JKzMyACw/oHwEu3gqO9X39Z0VyAWFU9ReuG2HK3eLdxd8uCX4YRnDrrWsEbcJuczuA==",
       "dependencies": {
         "@carbon/colors": "^10.34.0",
         "@carbon/layout": "^10.34.0",
-        "@carbon/type": "^10.38.0",
+        "@carbon/type": "^10.39.0",
         "color": "^3.1.2"
       }
     },
     "node_modules/@carbon/type": {
-      "version": "10.38.0",
-      "resolved": "https://registry.npmjs.org/@carbon/type/-/type-10.38.0.tgz",
-      "integrity": "sha512-I1Xc9s7LPdAX4KRrOZl8sIv+c0uFnIdVBSwBnBODB3ZJ+EiZgaNdvWKOlkoYRA07Vn1VUcptwkBDuXXO1vHL0A==",
+      "version": "10.39.0",
+      "resolved": "https://registry.npmjs.org/@carbon/type/-/type-10.39.0.tgz",
+      "integrity": "sha512-1Js2kJv79Y8zvpAs5qdkZUB0lE4j59+Mk73x19+L3Bla7n6TZ8IsafPyLg7aIDkqZSCYatGt7gw8bB8NOg/VQA==",
       "dependencies": {
         "@carbon/import-once": "^10.6.0",
         "@carbon/layout": "^10.34.0"
@@ -3959,9 +3959,9 @@
       }
     },
     "node_modules/carbon-components": {
-      "version": "10.48.0",
-      "resolved": "https://registry.npmjs.org/carbon-components/-/carbon-components-10.48.0.tgz",
-      "integrity": "sha512-kz6WlB4sVyOW/fUZLQ+f83cS2AAvcNRXkMi6au1guUHMdoTtIBz62AGKGxq54Xy2hQZK0Ca6aH01NopxOV4wUw==",
+      "version": "10.50.0",
+      "resolved": "https://registry.npmjs.org/carbon-components/-/carbon-components-10.50.0.tgz",
+      "integrity": "sha512-MAtqZMQbOzrzO7X8tjlhDrWzF6VnjM19OIYqTuOsDv5XmiGNnmBqnPSFBi2n2PPGLXKnpOnHAXYVx5yQIHSKLQ==",
       "hasInstallScript": true,
       "dependencies": {
         "@carbon/telemetry": "0.0.0-alpha.6",
@@ -3974,14 +3974,14 @@
       }
     },
     "node_modules/carbon-components-react": {
-      "version": "7.48.1",
-      "resolved": "https://registry.npmjs.org/carbon-components-react/-/carbon-components-react-7.48.1.tgz",
-      "integrity": "sha512-41l294GoKsKZ3Ncc0SJZ/NyaGUGq4Kmer4WR7PzI44z3RTCrF2LjcgjcXAn4Etvea35vdY6Reb4bPtFkmPT4TA==",
+      "version": "7.50.0",
+      "resolved": "https://registry.npmjs.org/carbon-components-react/-/carbon-components-react-7.50.0.tgz",
+      "integrity": "sha512-HM7cj1AHQ/v385+eenbt2A0/RaFYMCahSsemEHG8jyf/4ESjpad3hCgP6BQ0UhZAS0X5EsX5LX6OHSSKywWdeA==",
       "hasInstallScript": true,
       "dependencies": {
         "@babel/runtime": "^7.14.6",
         "@carbon/feature-flags": "^0.6.0",
-        "@carbon/icons-react": "^10.43.0",
+        "@carbon/icons-react": "^10.44.0",
         "@carbon/layout": "^10.34.0",
         "@carbon/telemetry": "0.0.0-alpha.6",
         "classnames": "2.3.1",
@@ -16168,7 +16168,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@carbon-platform/icons": "0.0.8",
-        "@carbon/react": "^0.8.0",
+        "@carbon/react": "^0.11.0",
         "@octokit/core": "^3.5.1",
         "cache-manager": "^3.6.0",
         "cache-manager-fs-hash": "^1.0.0",
@@ -16713,7 +16713,7 @@
       "version": "file:services/web-app",
       "requires": {
         "@carbon-platform/icons": "0.0.8",
-        "@carbon/react": "^0.8.0",
+        "@carbon/react": "0.11.0",
         "@octokit/core": "^3.5.1",
         "cache-manager": "^3.6.0",
         "cache-manager-fs-hash": "^1.0.0",
@@ -16774,9 +16774,9 @@
       "integrity": "sha512-jvDUKz3NLopiDf7BROLDAT4NoswMpeXg4+ulbkLlFHdgY3v7gaxT/MJ7f9DZeEIiYUBhQSjTmcB3agIIO1jOdw=="
     },
     "@carbon/icons-react": {
-      "version": "10.43.0",
-      "resolved": "https://registry.npmjs.org/@carbon/icons-react/-/icons-react-10.43.0.tgz",
-      "integrity": "sha512-BtRX3/wMqH3BrP1O32CKwz2DmuE351NVkk0gYuASIfDBOOf4BsZ30hBo7p6rUJ3JdjG0wXzbJgXD2XbvvHQIYw==",
+      "version": "10.44.0",
+      "resolved": "https://registry.npmjs.org/@carbon/icons-react/-/icons-react-10.44.0.tgz",
+      "integrity": "sha512-1M8J0/vMHYj5Bd4GmgkMP+tCsAD1gRCoiZYHNhohJb6ed40c2yaLa7DQ89PLStocZR9ZNtvc3akR00Ro3uiNWA==",
       "requires": {
         "@carbon/icon-helpers": "^10.25.0",
         "@carbon/telemetry": "0.0.0-alpha.6",
@@ -16799,31 +16799,31 @@
       "integrity": "sha512-xNkDoRBfNsTKsUR0Hk7FItcdCDH7Mrn0mwvV83C8srV0M4x1D9Uh6Mg7pO9YLbUDMNEmihYp5u4Lf9zJv+XEVg=="
     },
     "@carbon/react": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/@carbon/react/-/react-0.8.2.tgz",
-      "integrity": "sha512-rx9oxKhdqOWJdSvZzMEYJGJs1tX7KrTVafuME4aMfLSbiZPFziWNmac6jjdaVZy9lErxIN+9gYkFCCYjoL5z0A==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@carbon/react/-/react-0.11.0.tgz",
+      "integrity": "sha512-yaee2EU0AhtW1y/kioptvETRG3CwWkoo3l/BMMqrTp8/f4zwquIzzGQNtHXsjRxoqRM/By7wskiyuhXEnN2wpA==",
       "requires": {
         "@carbon/feature-flags": "^0.6.0",
-        "@carbon/icons-react": "^10.42.0",
-        "@carbon/styles": "^0.8.0",
+        "@carbon/icons-react": "^10.44.0",
+        "@carbon/styles": "^0.11.0",
         "@carbon/telemetry": "0.0.0-alpha.6",
-        "carbon-components": "^10.47.1",
-        "carbon-components-react": "^7.47.2",
+        "carbon-components": "^10.50.0",
+        "carbon-components-react": "^7.50.0",
         "carbon-icons": "^7.0.7"
       }
     },
     "@carbon/styles": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@carbon/styles/-/styles-0.8.0.tgz",
-      "integrity": "sha512-lykAX92/lTJ7mn7gkO0ykDbJtM+/DeOVyxnTfI0FXjBWyxgKAQ6abch7RKau80H3eVQSVxm+5Hsyj7C+v7cDjQ==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@carbon/styles/-/styles-0.11.0.tgz",
+      "integrity": "sha512-R2NyAellW3WtOaCsWaE8cBOJAl1gXqVJNcPYJSNp+eq2aFpWWyqrpYdMSG2ptUQrUbjPyz2IlP5iQIWI/10gBg==",
       "requires": {
         "@carbon/colors": "^10.34.0",
         "@carbon/feature-flags": "^0.6.0",
         "@carbon/grid": "^10.39.0",
         "@carbon/layout": "^10.34.0",
         "@carbon/motion": "^10.26.0",
-        "@carbon/themes": "^10.46.0",
-        "@carbon/type": "^10.38.0",
+        "@carbon/themes": "^10.48.0",
+        "@carbon/type": "^10.39.0",
         "@ibm/plex": "6.0.0-next.6"
       }
     },
@@ -16892,20 +16892,20 @@
       }
     },
     "@carbon/themes": {
-      "version": "10.47.0",
-      "resolved": "https://registry.npmjs.org/@carbon/themes/-/themes-10.47.0.tgz",
-      "integrity": "sha512-/HDFq5JeQbxADhV8yCcNpTN2sNMlgTjaEBtgPDdmLlqU2hj5cl7NwHXGcixVfZa9Kp+Nha+njx9+shM19nd7ag==",
+      "version": "10.48.0",
+      "resolved": "https://registry.npmjs.org/@carbon/themes/-/themes-10.48.0.tgz",
+      "integrity": "sha512-g0dqvWQHPwWW1y+BSuu5JKzMyACw/oHwEu3gqO9X39Z0VyAWFU9ReuG2HK3eLdxd8uCX4YRnDrrWsEbcJuczuA==",
       "requires": {
         "@carbon/colors": "^10.34.0",
         "@carbon/layout": "^10.34.0",
-        "@carbon/type": "^10.38.0",
+        "@carbon/type": "^10.39.0",
         "color": "^3.1.2"
       }
     },
     "@carbon/type": {
-      "version": "10.38.0",
-      "resolved": "https://registry.npmjs.org/@carbon/type/-/type-10.38.0.tgz",
-      "integrity": "sha512-I1Xc9s7LPdAX4KRrOZl8sIv+c0uFnIdVBSwBnBODB3ZJ+EiZgaNdvWKOlkoYRA07Vn1VUcptwkBDuXXO1vHL0A==",
+      "version": "10.39.0",
+      "resolved": "https://registry.npmjs.org/@carbon/type/-/type-10.39.0.tgz",
+      "integrity": "sha512-1Js2kJv79Y8zvpAs5qdkZUB0lE4j59+Mk73x19+L3Bla7n6TZ8IsafPyLg7aIDkqZSCYatGt7gw8bB8NOg/VQA==",
       "requires": {
         "@carbon/import-once": "^10.6.0",
         "@carbon/layout": "^10.34.0"
@@ -19244,9 +19244,9 @@
       "integrity": "sha512-9RoKo841j1GQFSJz/nCXOj0sD7tHBtlowjYlrqIUS812x9/emfBLBt6IyMz1zIaYc/eRL8Cs6HPUVi2Hzq4sIg=="
     },
     "carbon-components": {
-      "version": "10.48.0",
-      "resolved": "https://registry.npmjs.org/carbon-components/-/carbon-components-10.48.0.tgz",
-      "integrity": "sha512-kz6WlB4sVyOW/fUZLQ+f83cS2AAvcNRXkMi6au1guUHMdoTtIBz62AGKGxq54Xy2hQZK0Ca6aH01NopxOV4wUw==",
+      "version": "10.50.0",
+      "resolved": "https://registry.npmjs.org/carbon-components/-/carbon-components-10.50.0.tgz",
+      "integrity": "sha512-MAtqZMQbOzrzO7X8tjlhDrWzF6VnjM19OIYqTuOsDv5XmiGNnmBqnPSFBi2n2PPGLXKnpOnHAXYVx5yQIHSKLQ==",
       "requires": {
         "@carbon/telemetry": "0.0.0-alpha.6",
         "flatpickr": "4.6.1",
@@ -19255,13 +19255,13 @@
       }
     },
     "carbon-components-react": {
-      "version": "7.48.1",
-      "resolved": "https://registry.npmjs.org/carbon-components-react/-/carbon-components-react-7.48.1.tgz",
-      "integrity": "sha512-41l294GoKsKZ3Ncc0SJZ/NyaGUGq4Kmer4WR7PzI44z3RTCrF2LjcgjcXAn4Etvea35vdY6Reb4bPtFkmPT4TA==",
+      "version": "7.50.0",
+      "resolved": "https://registry.npmjs.org/carbon-components-react/-/carbon-components-react-7.50.0.tgz",
+      "integrity": "sha512-HM7cj1AHQ/v385+eenbt2A0/RaFYMCahSsemEHG8jyf/4ESjpad3hCgP6BQ0UhZAS0X5EsX5LX6OHSSKywWdeA==",
       "requires": {
         "@babel/runtime": "^7.14.6",
         "@carbon/feature-flags": "^0.6.0",
-        "@carbon/icons-react": "^10.43.0",
+        "@carbon/icons-react": "^10.44.0",
         "@carbon/layout": "^10.34.0",
         "@carbon/telemetry": "0.0.0-alpha.6",
         "classnames": "2.3.1",

--- a/services/web-app/components/catalog-item/catalog-item.module.scss
+++ b/services/web-app/components/catalog-item/catalog-item.module.scss
@@ -34,7 +34,7 @@
 
 .anchor {
   display: block;
-  background: $background;
+  background: $layer-01;
   text-decoration: none;
   transition: background $fast-02 carbon--motion(standard, productive);
 

--- a/services/web-app/components/catalog-list/catalog-list.js
+++ b/services/web-app/components/catalog-list/catalog-list.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import { Column, Grid, Layer, Theme } from '@carbon/react'
+import { Column, Grid } from '@carbon/react'
 import clsx from 'clsx'
 
 import CatalogItem from '@/components/catalog-item'
@@ -22,30 +22,25 @@ const CatalogList = ({ assets, isGrid = false, page = 1, pageSize = 10 }) => {
   const renderAssets = assets.slice(start, end)
 
   return (
-    <Theme theme="white">
-      <Layer>
-        <Grid as="ul" className={isNarrow && styles.grid} narrow={isNarrow}>
-          {renderAssets.map((asset, i) => (
-            <CatalogItem asset={asset} key={i} isGrid={isGrid && isLg} />
-          ))}
-          {(!renderAssets || renderAssets.length === 0) && (
-            <Column
-              className={clsx(styles.copy, isNarrow && styles.copyGrid)}
-              sm={4}
-              md={8}
-              lg={12}
-            >
-              <h2 className={styles.heading}>No results found</h2>
-              <p className={styles.paragraph}>
-                {
-                  "It appears we don't have any assets that match your search. Try different search terms."
-                }
-              </p>
-            </Column>
-          )}
-        </Grid>
-      </Layer>
-    </Theme>
+    <Grid
+      as="ul"
+      className={clsx(styles.container, isNarrow && styles.containerGrid)}
+      narrow={isNarrow}
+    >
+      {renderAssets.map((asset, i) => (
+        <CatalogItem asset={asset} key={i} isGrid={isGrid && isLg} />
+      ))}
+      {(!renderAssets || renderAssets.length === 0) && (
+        <Column className={clsx(styles.copy, isNarrow && styles.copyGrid)} sm={4} md={8} lg={12}>
+          <h2 className={styles.heading}>No results found</h2>
+          <p className={styles.paragraph}>
+            {
+              "It appears we don't have any assets that match your search. Try different search terms."
+            }
+          </p>
+        </Column>
+      )}
+    </Grid>
   )
 }
 

--- a/services/web-app/components/catalog-list/catalog-list.module.scss
+++ b/services/web-app/components/catalog-list/catalog-list.module.scss
@@ -5,10 +5,14 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-.grid {
-  margin-top: $spacing-05;
-  margin-bottom: $spacing-05;
-  row-gap: $spacing-05;
+.container {
+  background: $background;
+
+  &--grid {
+    margin-top: $spacing-05;
+    margin-bottom: $spacing-05;
+    row-gap: $spacing-05;
+  }
 }
 
 .copy {

--- a/services/web-app/components/catalog-pagination/catalog-pagination.js
+++ b/services/web-app/components/catalog-pagination/catalog-pagination.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import { Column, Grid, Layer, Pagination, Theme } from '@carbon/react'
+import { Column, Grid, Pagination } from '@carbon/react'
 
 import { mediaQueries, useMatchMedia } from '@/utils/use-match-media'
 
@@ -19,28 +19,30 @@ const CatalogPagination = ({
 }) => {
   const isMd = useMatchMedia(mediaQueries.md)
 
+  /**
+   * @todo the Pagination component is missing icons for next page and previous page using the
+   * latest `@carbon/react@0.11.0`. This has been reported:
+   * {@link https://github.com/carbon-design-system/carbon/discussions/10247}.
+   */
+
   return (
-    <Theme className={styles.container} theme="white">
-      <Layer>
-        <Grid condensed={!isMd} narrow={isMd}>
-          <Column className={styles.column} sm={4} md={8} lg={12}>
-            <Pagination
-              onChange={({ page, pageSize }) => {
-                if (pageSize !== currentPageSize) {
-                  setPageSize(pageSize)
-                } else {
-                  setPage(page)
-                }
-              }}
-              page={currentPage}
-              pageSize={currentPageSize}
-              pageSizes={[12, 24, 48, 96]}
-              totalItems={assets.length}
-            />
-          </Column>
-        </Grid>
-      </Layer>
-    </Theme>
+    <Grid className={styles.container} condensed={!isMd} narrow={isMd}>
+      <Column className={styles.column} sm={4} md={8} lg={12}>
+        <Pagination
+          onChange={({ page, pageSize }) => {
+            if (pageSize !== currentPageSize) {
+              setPageSize(pageSize)
+            } else {
+              setPage(page)
+            }
+          }}
+          page={currentPage}
+          pageSize={currentPageSize}
+          pageSizes={[12, 24, 48, 96]}
+          totalItems={assets.length}
+        />
+      </Column>
+    </Grid>
   )
 }
 

--- a/services/web-app/components/catalog-search/catalog-search.js
+++ b/services/web-app/components/catalog-search/catalog-search.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import { Column, Grid, Layer, MultiSelect, Search, Theme } from '@carbon/react'
+import { Column, Grid, MultiSelect, Search } from '@carbon/react'
 
 import { mediaQueries, useMatchMedia } from '@/utils/use-match-media'
 
@@ -32,34 +32,30 @@ const CatalogSearch = ({ search = '', onSearch }) => {
   ]
 
   return (
-    <Theme className={styles.container} theme="white">
-      <Layer>
-        <Grid condensed={!isMd} narrow={isMd}>
-          <Column className={styles.column} sm={2} md={4} lg={8}>
-            <Search
-              id="catalog-search"
-              labelText="Search component index by name, keyword, or domain"
-              placeholder="Component name, keyword, domain"
-              value={search}
-              onBlur={handleOnBlur}
-              onChange={handleOnChange}
-              onClear={handleOnClear}
-              size="lg"
-            />
-          </Column>
-          <Column className={styles.column} sm={2} md={4} lg={4}>
-            <MultiSelect
-              id="catalog-filter"
-              label="Filters"
-              items={items}
-              itemToString={(item) => (item ? item.text : '')}
-              initialSelectedItems={[items[0], items[1]]}
-              size="lg"
-            />
-          </Column>
-        </Grid>
-      </Layer>
-    </Theme>
+    <Grid className={styles.container} condensed={!isMd} narrow={isMd}>
+      <Column className={styles.column} sm={2} md={4} lg={8}>
+        <Search
+          id="catalog-search"
+          labelText="Search component index by name, keyword, or domain"
+          placeholder="Component name, keyword, domain"
+          value={search}
+          onBlur={handleOnBlur}
+          onChange={handleOnChange}
+          onClear={handleOnClear}
+          size="lg"
+        />
+      </Column>
+      <Column className={styles.column} sm={2} md={4} lg={4}>
+        <MultiSelect
+          id="catalog-filter"
+          label="Filters"
+          items={items}
+          itemToString={(item) => (item ? item.text : '')}
+          initialSelectedItems={[items[0], items[1]]}
+          size="lg"
+        />
+      </Column>
+    </Grid>
   )
 }
 

--- a/services/web-app/components/catalog-search/catalog-search.module.scss
+++ b/services/web-app/components/catalog-search/catalog-search.module.scss
@@ -6,8 +6,9 @@
 //
 
 .container {
+  // position above CatalogSort
   position: sticky;
-  z-index: 1;
+  z-index: 2;
   top: $spacing-09 + $spacing-05;
   @include breakpoint-down(md) {
     top: $spacing-09;
@@ -20,13 +21,19 @@
     bottom: 100%;
     left: -$spacing-05;
     height: $spacing-05;
-    background: $layer-01;
+    background: $background;
     content: '';
   }
 
   // override carbon display
   :global(.cds--label) {
     display: none;
+  }
+
+  // TODO temporarily fix search bar height until its fixed upstream after `@carbon/react@0.11.0`,
+  // tracked here: https://github.com/carbon-design-system/carbon/discussions/10247
+  :global(.cds--search--lg .cds--search-input) {
+    height: $spacing-09;
   }
 }
 

--- a/services/web-app/components/catalog-sort/catalog-sort.js
+++ b/services/web-app/components/catalog-sort/catalog-sort.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import { Button, Column, Dropdown, Grid, Layer, Theme } from '@carbon/react'
+import { Column, Dropdown, Grid, IconButton } from '@carbon/react'
 import { Grid as GridIcon, List as ListIcon } from '@carbon/react/icons'
 import clsx from 'clsx'
 import { useCallback, useEffect, useRef, useState } from 'react'
@@ -46,54 +46,50 @@ const CatalogSort = ({ onSort, onView, sort, view }) => {
 
   return (
     <div className={clsx(styles.container, isSticky && styles.containerSticky)} ref={containerRef}>
-      <Theme theme="white">
-        <Layer>
-          <Grid className={styles.grid} condensed={!isMd} narrow={isMd}>
-            <Column className={styles.column} sm={4} md={8} lg={4}>
-              <Dropdown
-                id="catalog-sort"
-                className={styles.dropdown}
-                initialSelectedItem={sortItems.find((item) => item.id === sort)}
-                items={sortItems}
-                itemToString={(item) => (item ? item.text : '')}
-                onChange={({ selectedItem }) => {
-                  onSort(selectedItem.id)
-                }}
-                type="inline"
-                titleText="Sort by:"
-                label="A–Z"
-                size="lg"
-              />
-            </Column>
-            <Column className={`${styles.column} ${styles.columnSwitcher}`} lg={8}>
-              <div className={styles.switcher}>
-                <Button
-                  className={view === 'grid' ? styles.selected : null}
-                  size="lg"
-                  kind="ghost"
-                  renderIcon={GridIcon}
-                  iconDescription="Grid view"
-                  hasIconOnly
-                  onClick={() => {
-                    onView('grid')
-                  }}
-                />
-                <Button
-                  className={view === 'list' ? styles.selected : null}
-                  size="lg"
-                  kind="ghost"
-                  renderIcon={ListIcon}
-                  iconDescription="List view"
-                  hasIconOnly
-                  onClick={() => {
-                    onView('list')
-                  }}
-                />
-              </div>
-            </Column>
-          </Grid>
-        </Layer>
-      </Theme>
+      <Grid className={styles.grid} condensed={!isMd} narrow={isMd}>
+        <Column className={styles.column} sm={4} md={8} lg={4}>
+          <Dropdown
+            id="catalog-sort"
+            className={styles.dropdown}
+            initialSelectedItem={sortItems.find((item) => item.id === sort)}
+            items={sortItems}
+            itemToString={(item) => (item ? item.text : '')}
+            onChange={({ selectedItem }) => {
+              onSort(selectedItem.id)
+            }}
+            type="inline"
+            titleText="Sort by:"
+            label="A–Z"
+            size="lg"
+          />
+        </Column>
+        <Column className={`${styles.column} ${styles.columnSwitcher}`} lg={8}>
+          <div className={styles.switcher}>
+            <IconButton
+              className={clsx(styles.button, view === 'grid' && styles.selected)}
+              kind="ghost"
+              label="Grid view"
+              onClick={() => {
+                onView('grid')
+              }}
+              size="lg"
+            >
+              <GridIcon size={20} />
+            </IconButton>
+            <IconButton
+              className={clsx(styles.button, view === 'list' && styles.selected)}
+              kind="ghost"
+              label="List view"
+              onClick={() => {
+                onView('list')
+              }}
+              size="lg"
+            >
+              <ListIcon size={20} />
+            </IconButton>
+          </div>
+        </Column>
+      </Grid>
     </div>
   )
 }

--- a/services/web-app/components/catalog-sort/catalog-sort.module.scss
+++ b/services/web-app/components/catalog-sort/catalog-sort.module.scss
@@ -30,11 +30,11 @@
 }
 
 .grid {
-  background: $background;
+  background: $layer-01;
 }
 
 .column {
-  background: $background;
+  background: $layer-01;
 
   &:not(:last-child) {
     @include breakpoint(lg) {
@@ -77,6 +77,18 @@
   :global(.cds--list-box__field),
   :global(.cds--list-box__menu) {
     max-width: none;
+  }
+}
+
+.button {
+  // override carbon because `lg` isn't supported
+  width: $spacing-09;
+  height: $spacing-09;
+
+  // override icon alignment because the IconButton only supports `sm` size currently
+  &:global(.cds--btn--sm) {
+    padding-right: 14px;
+    padding-left: 14px;
   }
 }
 

--- a/services/web-app/layouts/layout/layout.js
+++ b/services/web-app/layouts/layout/layout.js
@@ -45,12 +45,18 @@ const Layout = ({ children }) => {
   const router = useRouter()
   const { navData } = useContext(LayoutContext)
 
+  /**
+   * @todo the HeaderGlobalAction component has icons that aren't centered using the latest
+   * `@carbon/react@0.11.0`. This has been reported:
+   * {@link https://github.com/carbon-design-system/carbon/discussions/10247}.
+   */
+
   return (
     <HeaderContainer
       render={({ isSideNavExpanded, onClickSideNavExpand }) => (
         <>
           <Theme theme="g100">
-            <Header aria-label="IBM Platform Name">
+            <Header aria-label="Carbon Design System">
               <SkipToContent />
               <HeaderMenuButton
                 aria-label="Open menu"

--- a/services/web-app/package.json
+++ b/services/web-app/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@carbon-platform/icons": "0.0.9",
-    "@carbon/react": "^0.8.0",
+    "@carbon/react": "^0.11.0",
     "@octokit/core": "^3.5.1",
     "cache-manager": "^3.6.0",
     "cache-manager-fs-hash": "^1.0.0",

--- a/services/web-app/package.json
+++ b/services/web-app/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@carbon-platform/icons": "0.0.8",
-    "@carbon/react": "^0.8.0",
+    "@carbon/react": "^0.11.0",
     "@octokit/core": "^3.5.1",
     "cache-manager": "^3.6.0",
     "cache-manager-fs-hash": "^1.0.0",


### PR DESCRIPTION
Upgrades `@carbon/react` to the latest 0.11.0

#### Changelog

**New**

- Overrides and and TODOs to patch bugs recently introduced in 0.11.0

**Changed**

- Fixed bug where sort row was covering search row dropdown
- Removed Theme and Layer instances that are no longer needed

**Removed**

- Theme and Layer components that are no longer needed due to the upstream fixes

#### Testing / reviewing

Should look the same as before.