### PR TITLE
feat: apply filter to lists

### DIFF
--- a/services/web-app/pages/assets/components.js
+++ b/services/web-app/pages/assets/components.js
@@ -26,7 +26,11 @@ const Components = ({ librariesData }) => {
   return (
     <>
       <NextSeo {...seo} />
-      <Catalog data={librariesData} type="component" />
+      <Catalog
+        data={librariesData}
+        filter={{ sponsor: ['carbon'], status: ['stable'], framework: ['react'] }}
+        type="component"
+      />
     </>
   )
 }


### PR DESCRIPTION
Filter the catalog.

#### Changelog

**New**

- The default filter for all catalogs is stable status.
- Components catalog has a different default filter, as carbon sponsor, react framework, stable status.

**Changed**

- Fixed a bug when searching and the asset doesn't have a name or description.

**Removed**

- N/A

#### Testing / reviewing

Go to a URL like this to see a non-default filter, or, interact with the filter:

http://localhost:3000/assets/components?filter=%7B%22sponsor%22%3A%5B%22ibm-dotcom%22%5D%2C%22framework%22%3A%5B%22react%22%5D%2C%22status%22%3A%5B%22stable%22%5D%7D&view=grid&sort=status&q=card

Which renders:
![image](https://user-images.githubusercontent.com/1691245/146988515-5d236ca4-0387-4676-b0e4-e8c98a6c4329.png)
