### PR TITLE
fix: use explicit key on catalogItem, prevent react unstable comp state

### DIFF
--- a/services/web-app/components/catalog-list/catalog-list.js
+++ b/services/web-app/components/catalog-list/catalog-list.js
@@ -8,6 +8,7 @@ import { Column, Grid } from '@carbon/react'
 import clsx from 'clsx'
 
 import CatalogItem from '@/components/catalog-item'
+import { getSlug } from '@/utils/slug'
 import { mediaQueries, useMatchMedia } from '@/utils/use-match-media'
 
 import styles from './catalog-list.module.scss'
@@ -28,7 +29,7 @@ const CatalogList = ({ assets, isGrid = false, page = 1, pageSize = 10 }) => {
       narrow={isNarrow}
     >
       {renderAssets.map((asset, i) => (
-        <CatalogItem asset={asset} key={i} isGrid={isGrid && isLg} />
+        <CatalogItem asset={asset} key={`${i}-${getSlug(asset.content)}`} isGrid={isGrid && isLg} />
       ))}
       {(!renderAssets || renderAssets.length === 0) && (
         <Column className={clsx(styles.copy, isNarrow && styles.copyGrid)} sm={4} md={8} lg={12}>


### PR DESCRIPTION
Closes #178 

Used explicit key in map for catalogItem component to prevent unstable react state, see: https://reactjs.org/docs/lists-and-keys.html#keys

#### Changelog

**Changed**

- services/web-app/components/catalog-list/catalog-list.js: include asset slug in catalog key

#### Testing / reviewing

Pull changes and verify correct app performance and thumbnail placement
