### PR TITLE
fix: ending / when comparing filepath to avoid picking up similar libs

### DIFF
--- a/services/web-app/lib/github.js
+++ b/services/web-app/lib/github.js
@@ -188,7 +188,7 @@ const getLibraryAssets = async (params = {}, inheritContent = false) => {
   const assetContentPromises = treeResponse.tree
     .filter(
       (file) =>
-        removeLeadingSlash(file.path).startsWith(removeLeadingSlash(libraryParams.path)) &&
+        removeLeadingSlash(file.path).startsWith(removeLeadingSlash(libraryParams.path) + '/') &&
         file.path.endsWith('carbon-asset.yml')
     )
     .map((file) => {

--- a/services/web-app/lib/github.js
+++ b/services/web-app/lib/github.js
@@ -12,7 +12,7 @@ import { IMAGES_CACHE_PATH } from '@/config/constants'
 import { libraryAllowList } from '@/data/libraries'
 import { getResponse, writeFile } from '@/lib/file-cache'
 import { getSlug } from '@/utils/slug'
-import { removeLeadingSlash } from '@/utils/string'
+import { addTrailingSlash, removeLeadingSlash } from '@/utils/string'
 
 /**
  * Validates the route's parameters and returns an object that also includes the library's slug as
@@ -188,8 +188,9 @@ const getLibraryAssets = async (params = {}, inheritContent = false) => {
   const assetContentPromises = treeResponse.tree
     .filter(
       (file) =>
-        removeLeadingSlash(file.path).startsWith(removeLeadingSlash(libraryParams.path) + '/') &&
-        file.path.endsWith('carbon-asset.yml')
+        removeLeadingSlash(file.path).startsWith(
+          removeLeadingSlash(addTrailingSlash(libraryParams.path))
+        ) && file.path.endsWith('carbon-asset.yml')
     )
     .map((file) => {
       return getResponse(libraryParams.host, 'GET /repos/{owner}/{repo}/contents/{path}', {

--- a/services/web-app/utils/string.js
+++ b/services/web-app/utils/string.js
@@ -13,3 +13,12 @@
 export const removeLeadingSlash = (str) => {
   return str.replace(/^\/+/, '')
 }
+
+/**
+ * Add a trailinsh slash to a string
+ * @param {string} str
+ * @returns {string} A string with a trailing slash
+ */
+export const addTrailingSlash = (str) => {
+  return str.endsWith('/') ? str : `${str}/`
+}


### PR DESCRIPTION
Find carbon-asset.yml files inside a specific library by delimitating the library name end with a /, so if the librabry name is 'carbon-cli' , we match files starting like carbon-cli/*/carbon-asset.yml and ignore files starting like carbon-cli-reporter/*/carbon-asset.yml

#### Changelog


**Changed**

- services/web-app/lib/github.js: compare with ending /


#### Testing / reviewing

test application functionality and that under functions only one reporter is rendered