### PR TITLE
feat: remove unused web app nav items

### DIFF
--- a/docs/resource-schemas.md
+++ b/docs/resource-schemas.md
@@ -81,7 +81,7 @@ demoLinks:
 | `name` | Asset display name. Use sentence-case capitalization. | Required | String | – | – |
 | `description` | Asset description ideally between 50-160 characters in length. Use sentence-case capitalization. | Required | String | – | – |
 | `status` | Asset consumption exptectations. See [asset status](#asset-status). | Required | String \| Object | `draft` | `draft`, `experimental`, `stable`, `deprecated` |
-| `type` | Asset primary categorization. See [asset type](#asset-type). | Required | String | – | `component`, `element`, `function`, `pattern`, `template` |
+| `type` | Asset primary categorization. See [asset type](#asset-type). | Required | String | – | `component`, `function`, `pattern`, `template` |
 | `tags` | Asset secondary categorizations. See [asset tags](#asset-tags). | Optional | Array | – | `content-block`, `content-element`, `contextual-navigation`, `data-display`, `data-visualization`, `form`, `input-control`, `media`, `shell`, `structural-navigation`, `system-feedback`, `comparison`, `connection`, `correlation`, `geographic-overlay`, `geospatial-distortion`, `part-to-whole`, `trend`, `hook`, `service`, `utility` |
 | `framework` | Asset primary technology dependency. See [asset framework](#asset-framework). | Optional | String | `design-only` | `angular`, `react`, `react-native`, `svelte`, `vanilla`, `vue`, `web-component`, `design-only` |
 | `platform` | Runtime where the asset can be used. See [asset platform](#asset-platform). | Optional | String | `web` | `cross-platform`, `web` |
@@ -122,11 +122,13 @@ status:
 Asset type is used for primary categorization in asset catalogs. The `type` key can have the
 following values:
 
+<!-- remove element asset type for first release -->
+<!-- | `element` | Styles, tokens, icons, and pictograms that are the direct translation of design language elements to digital mediums. | -->
+
 <!-- prettier-ignore -->
 | Type | Description |
 | --- | --- |
 | `component` | Building blocks that have been designed and coded to solve a specific user interface problem. |
-| `element` | Styles, tokens, icons, and pictograms that are the direct translation of design language elements to digital mediums. |
 | `function` | Code that performs a single action or actions and has no user interface. |
 | `pattern` | Best practice solution for how a user achieves a goal through reusable combinations of components and content with sequences and flows which are too complex to be encapsulated in a single component. |
 | `template` | Layout example that specifies patterns and component order and placement to compose a specific view. |

--- a/services/web-app/data/nav-data.js
+++ b/services/web-app/data/nav-data.js
@@ -6,10 +6,11 @@
  */
 
 export const globalNavData = [
-  {
-    path: '/standards',
-    title: 'Standards'
-  },
+  // remove standards for the first release
+  // {
+  //   path: '/standards',
+  //   title: 'Standards'
+  // },
   {
     path: '/assets',
     title: 'Assets'
@@ -19,14 +20,14 @@ export const globalNavData = [
 export const standardsNavData = [
   {
     path: '/standards',
-    title: 'About standards'
+    title: 'About Standards'
   }
 ]
 
 export const assetsNavData = [
   {
     path: '/assets',
-    title: 'About assets'
+    title: 'About Assets'
   },
   {
     path: '/assets/libraries',
@@ -39,10 +40,11 @@ export const assetsNavData = [
         path: '/assets/components',
         title: 'Components'
       },
-      {
-        path: '/assets/elements',
-        title: 'Elements'
-      },
+      // remove elements for the first release
+      // {
+      //   path: '/assets/elements',
+      //   title: 'Elements'
+      // },
       {
         path: '/assets/functions',
         title: 'Functions'

--- a/services/web-app/layouts/layout/layout.js
+++ b/services/web-app/layouts/layout/layout.js
@@ -18,12 +18,10 @@ import {
   SideNav,
   SideNavItems,
   SideNavLink,
-  SideNavMenu,
-  SideNavMenuItem,
   SkipToContent,
   Theme
 } from '@carbon/react'
-import { Search, Switcher, User } from '@carbon/react/icons'
+import { User } from '@carbon/react/icons'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { createContext, useContext, useEffect, useState } from 'react'
@@ -68,7 +66,7 @@ const Layout = ({ children }) => {
                 onClick={onClickSideNavExpand}
                 isActive={isSideNavExpanded}
               />
-              <Link href="/">
+              <Link href="/assets">
                 <a className="cds--header__name">Carbon Design System</a>
               </Link>
               <HeaderNavigation aria-label="Main navigation">
@@ -84,14 +82,8 @@ const Layout = ({ children }) => {
                 ))}
               </HeaderNavigation>
               <HeaderGlobalBar>
-                <HeaderGlobalAction aria-label="Search">
-                  <Search size={20} />
-                </HeaderGlobalAction>
                 <HeaderGlobalAction aria-label="Log in" href="/api/login">
                   <User size={20} />
-                </HeaderGlobalAction>
-                <HeaderGlobalAction aria-label="Switch sites">
-                  <Switcher size={20} />
                 </HeaderGlobalAction>
               </HeaderGlobalBar>
             </Header>
@@ -125,18 +117,19 @@ const Layout = ({ children }) => {
                           }
                           if (!data.path && data.items) {
                             return (
-                              <SideNavMenu defaultExpanded={true} key={i} title={data.title}>
+                              <>
+                                <h2 className={styles.sideNavHeading}>{data.title}</h2>
                                 {data.items.map((item, j) => (
-                                  <SideNavMenuItem
+                                  <SideNavLink
                                     element={NextLink}
+                                    href={item.path}
                                     isActive={router.pathname.startsWith(item.path)}
-                                    to={item.path}
                                     key={j}
                                   >
                                     {item.title}
-                                  </SideNavMenuItem>
+                                  </SideNavLink>
                                 ))}
-                              </SideNavMenu>
+                              </>
                             )
                           }
                           return null

--- a/services/web-app/layouts/layout/layout.module.scss
+++ b/services/web-app/layouts/layout/layout.module.scss
@@ -19,3 +19,10 @@
     z-index: layout.z('overlay');
   }
 }
+
+.side-nav-heading {
+  padding-bottom: $spacing-03;
+  border-bottom: 1px solid $layer-accent;
+  margin: $spacing-08 $spacing-05 $spacing-03;
+  @include type-style('label-01');
+}

--- a/services/web-app/next.config.js
+++ b/services/web-app/next.config.js
@@ -60,6 +60,12 @@ module.exports = {
   },
   async redirects() {
     return [
+      // temporarily redirect home page for the first release
+      {
+        source: '/',
+        destination: '/assets',
+        permanent: false
+      },
       {
         source: '/assets/:host/:org/:repo/:library',
         destination: '/assets/:host/:org/:repo/:library/latest',


### PR DESCRIPTION
Closes #252 

#### Changelog

**New**

- `/` redirects to `/assets` because there is no home page yet and we might as well leave everything under the `/assets` route

**Changed**

- Side nav now has headings for groups instead of menus

**Removed**

- Standards and unused icons in global nav
- Elements from side nav and schema

#### Testing / reviewing

You still have to click the global nav user icon before seeing any page... the web app now looks like this:

<img width="1380" alt="image" src="https://user-images.githubusercontent.com/1691245/154742380-7d485b89-1ea6-491a-808b-b6471de6c069.png">

