### PR TITLE
fix: narrow grid in catalog search sort results and filter

### DIFF
--- a/services/web-app/components/catalog-item/catalog-item.js
+++ b/services/web-app/components/catalog-item/catalog-item.js
@@ -200,7 +200,7 @@ const CatalogItem = ({ asset, assetCounts, filter, isGrid = false }) => {
     <Column as="li" sm={4} md={8} lg={12}>
       <Link href={anchorHref}>
         <a className={anchorStyles} {...anchorProps}>
-          <Grid condensed={!isMd} narrow={isMd}>
+          <Grid condensed>
             <Column className={clsx(styles.column, styles.columnImage)} md={4}>
               <AspectRatio ratio={imageAspectRatio()}>
                 <CatalogItemImage asset={asset} />

--- a/services/web-app/components/catalog-item/catalog-item.module.scss
+++ b/services/web-app/components/catalog-item/catalog-item.module.scss
@@ -26,9 +26,6 @@
     @include breakpoint-down(md) {
       display: none;
     }
-    @include breakpoint(md) {
-      margin-right: calc(#{-$spacing-05} + 1px);
-    }
   }
 }
 
@@ -50,10 +47,6 @@
 
   &:not(.anchor--grid) {
     border-top: 1px solid $layer-accent;
-    @include breakpoint(md) {
-      padding-left: $spacing-05;
-      margin-left: -$spacing-05;
-    }
   }
 }
 

--- a/services/web-app/components/catalog-list/catalog-list.js
+++ b/services/web-app/components/catalog-list/catalog-list.js
@@ -24,7 +24,7 @@ const CatalogList = ({
   pageSize = 10
 }) => {
   const isLg = useMatchMedia(mediaQueries.lg)
-  const isNarrow = isGrid && isLg
+  const isLgGrid = isGrid && isLg
 
   const start = (page - 1) * pageSize
   const end = start + pageSize
@@ -32,11 +32,7 @@ const CatalogList = ({
   const renderAssets = assets.slice(start, end)
 
   return (
-    <Grid
-      as="ul"
-      className={clsx(styles.container, isNarrow && styles.containerGrid)}
-      narrow={isNarrow}
-    >
+    <Grid as="ul" className={clsx(styles.container, isLgGrid && styles.containerGrid)}>
       {renderAssets.map((asset, i) => (
         <CatalogItem
           assetCounts={assetCounts}
@@ -47,7 +43,7 @@ const CatalogList = ({
         />
       ))}
       {(!renderAssets || renderAssets.length === 0) && (
-        <Column className={clsx(styles.copy, isNarrow && styles.copyGrid)} sm={4} md={8} lg={12}>
+        <Column className={clsx(styles.copy, isLgGrid && styles.copyGrid)} sm={4} md={8} lg={12}>
           <h2 className={styles.heading}>No results found</h2>
           <p className={styles.paragraph}>
             {

--- a/services/web-app/components/catalog-list/catalog-list.module.scss
+++ b/services/web-app/components/catalog-list/catalog-list.module.scss
@@ -7,11 +7,19 @@
 
 .container {
   background: $background;
+  @include breakpoint(md) {
+    margin-right: -$spacing-05;
+    margin-left: -$spacing-05;
+  }
 
   &--grid {
     margin-top: $spacing-05;
     margin-bottom: $spacing-05;
     row-gap: $spacing-05;
+    --cds-grid-gutter: 1rem;
+    @include breakpoint(md) {
+      margin-right: 0;
+    }
   }
 }
 

--- a/services/web-app/components/catalog-multislect-filter/catalog-multiselect-filter.module.scss
+++ b/services/web-app/components/catalog-multislect-filter/catalog-multiselect-filter.module.scss
@@ -87,18 +87,18 @@
   width: 100vw;
   max-width: none;
   @include breakpoint(md) {
-    // span two columns, where each column has a 1px gutter and the first column is hanging
-    width: calc(200% + #{calc($spacing-05 + 2px)});
+    // span two columns, where each column has a 1px gutter
+    width: calc(200% + 2px);
   }
-  // span three columns, where each column has a 1px gutter and the first two columns are hanging
+  // span three columns, where each column has a 1px gutter
   @include breakpoint(lg) {
-    width: calc(300% + #{calc(($spacing-05 * 2) + 3px)});
+    width: calc(300% + 3px);
   }
 }
 
 .grid {
   position: relative;
-  padding: $spacing-03 $spacing-05 $spacing-03 0;
+  padding: $spacing-03 0;
 
   &::before,
   &::after {
@@ -119,14 +119,11 @@
 }
 
 .column {
-  padding: $spacing-06 0;
+  padding: $spacing-05;
   border-top: 1px solid $layer-accent;
-  margin: 0 $spacing-05;
   @include breakpoint(md) {
-    padding: $spacing-05 0 $spacing-05 $spacing-05;
     border-top: 0;
     border-left: 1px solid $layer-accent;
-    margin: 0;
     &:nth-child(2n + 1) {
       border-left: 0;
     }

--- a/services/web-app/components/catalog-multislect-filter/catalog-multiselect-filter.module.scss
+++ b/services/web-app/components/catalog-multislect-filter/catalog-multiselect-filter.module.scss
@@ -14,7 +14,7 @@
   position: relative;
   width: 100%;
   height: $spacing-09;
-  padding: 0 $spacing-04;
+  padding: 0 $spacing-05;
   border-top: 0;
   border-right: 0;
   border-bottom: 1px solid $border-strong;

--- a/services/web-app/components/catalog-pagination/catalog-pagination.js
+++ b/services/web-app/components/catalog-pagination/catalog-pagination.js
@@ -8,8 +8,6 @@ import { Column, Grid, Pagination } from '@carbon/react'
 import PropTypes from 'prop-types'
 import { assetPropTypes } from 'types'
 
-import { mediaQueries, useMatchMedia } from '@/utils/use-match-media'
-
 import styles from './catalog-pagination.module.scss'
 
 const CatalogPagination = ({
@@ -19,16 +17,8 @@ const CatalogPagination = ({
   setPage,
   setPageSize
 }) => {
-  const isMd = useMatchMedia(mediaQueries.md)
-
-  /**
-   * @todo the Pagination component is missing icons for next page and previous page using the
-   * latest `@carbon/react@0.11.0`. This has been reported:
-   * {@link https://github.com/carbon-design-system/carbon/discussions/10247}.
-   */
-
   return (
-    <Grid className={styles.container} condensed={!isMd} narrow={isMd}>
+    <Grid className={styles.container} condensed>
       <Column className={styles.column} sm={4} md={8} lg={12}>
         <Pagination
           onChange={({ page, pageSize }) => {
@@ -42,6 +32,7 @@ const CatalogPagination = ({
           pageSize={currentPageSize}
           pageSizes={[30, 60, 120, 240]}
           totalItems={assets.length}
+          size="lg"
         />
       </Column>
     </Grid>

--- a/services/web-app/components/catalog-pagination/catalog-pagination.module.scss
+++ b/services/web-app/components/catalog-pagination/catalog-pagination.module.scss
@@ -7,4 +7,8 @@
 
 .container {
   margin-bottom: $spacing-07;
+  @include breakpoint(md) {
+    margin-right: -$spacing-05;
+    margin-left: -$spacing-05;
+  }
 }

--- a/services/web-app/components/catalog-results/catalog-results.js
+++ b/services/web-app/components/catalog-results/catalog-results.js
@@ -8,15 +8,11 @@ import { Column, Grid } from '@carbon/react'
 import PropTypes from 'prop-types'
 import { assetPropTypes } from 'types'
 
-import { mediaQueries, useMatchMedia } from '@/utils/use-match-media'
-
 import styles from './catalog-results.module.scss'
 
 const CatalogResults = ({ assets = [] }) => {
-  const isMd = useMatchMedia(mediaQueries.md)
-
   return (
-    <Grid className={styles.container} condensed={!isMd} narrow={isMd}>
+    <Grid className={styles.container} condensed>
       <Column sm={4} md={8} lg={12}>
         <div className={styles.results}>{assets.length} results</div>
       </Column>

--- a/services/web-app/components/catalog-results/catalog-results.module.scss
+++ b/services/web-app/components/catalog-results/catalog-results.module.scss
@@ -6,8 +6,11 @@
 //
 
 .container {
-  margin-top: $spacing-07;
-  margin-bottom: $spacing-05;
+  margin: $spacing-07 0 $spacing-05;
+  @include breakpoint(md) {
+    margin-right: -$spacing-05;
+    margin-left: -$spacing-05;
+  }
 }
 
 .results {

--- a/services/web-app/components/catalog-search/catalog-search.js
+++ b/services/web-app/components/catalog-search/catalog-search.js
@@ -30,7 +30,7 @@ const CatalogSearch = ({ className, filter, initialFilter, onFilter, onSearch, s
   }
 
   return (
-    <Grid className={clsx(styles.container, className)} condensed={!isMd} narrow={isMd}>
+    <Grid className={clsx(styles.container, className)} condensed>
       <Column className={clsx(styles.column, styles.columnSearch)} sm={4} md={4} lg={8}>
         <Search
           id="catalog-search"

--- a/services/web-app/components/catalog-search/catalog-search.module.scss
+++ b/services/web-app/components/catalog-search/catalog-search.module.scss
@@ -7,13 +7,17 @@
 
 .container {
   // position above CatalogSort
-  // override grid gutter on sm
+  // override carbon grid gutter
   position: sticky;
   z-index: 2;
   top: $spacing-09 + $spacing-05;
+  --cds-grid-gutter: 0;
   @include breakpoint-down(md) {
     top: $spacing-09;
-    --cds-grid-gutter: 0;
+  }
+  @include breakpoint(md) {
+    margin-right: -$spacing-05;
+    margin-left: -$spacing-05;
   }
 
   // gray background above search when scrolled
@@ -41,12 +45,6 @@
 }
 
 .column {
-  &:not(:last-child) {
-    @include breakpoint(md) {
-      margin-right: -$spacing-05;
-    }
-  }
-
   &:not(:first-child) {
     border-left: 1px solid $layer-accent;
   }

--- a/services/web-app/components/catalog-sort/catalog-sort.js
+++ b/services/web-app/components/catalog-sort/catalog-sort.js
@@ -11,12 +11,10 @@ import PropTypes from 'prop-types'
 import { useCallback, useEffect, useRef, useState } from 'react'
 
 import useEventListener from '@/utils/use-event-listener'
-import { mediaQueries, useMatchMedia } from '@/utils/use-match-media'
 
 import styles from './catalog-sort.module.scss'
 
 const CatalogSort = ({ onSort, onView, sort, view }) => {
-  const isMd = useMatchMedia(mediaQueries.md)
   const containerRef = useRef(null)
   const [isSticky, setIsSticky] = useState(false)
 
@@ -47,7 +45,7 @@ const CatalogSort = ({ onSort, onView, sort, view }) => {
 
   return (
     <div className={clsx(styles.container, isSticky && styles.containerSticky)} ref={containerRef}>
-      <Grid className={styles.grid} condensed={!isMd} narrow={isMd}>
+      <Grid className={styles.grid} condensed>
         <Column className={styles.column} sm={4} md={8} lg={4}>
           <Dropdown
             id="catalog-sort"

--- a/services/web-app/components/catalog-sort/catalog-sort.module.scss
+++ b/services/web-app/components/catalog-sort/catalog-sort.module.scss
@@ -10,37 +10,23 @@
     position: sticky;
     z-index: 1;
     top: $spacing-09 + $spacing-05 + $spacing-09;
-  }
+    margin-right: -$spacing-05;
+    margin-left: -$spacing-05;
 
-  &::before {
-    position: absolute;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    left: -$spacing-05;
-    content: '';
-    transition: box-shadow $fast-02 carbon--motion(standard, productive);
-  }
-
-  &--sticky::before {
-    @include breakpoint(md) {
+    &--sticky {
       box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
     }
   }
 }
 
 .grid {
+  // override carbon grid gutter
   background: $layer-01;
+  --cds-grid-gutter: 0;
 }
 
 .column {
   background: $layer-01;
-
-  &:not(:last-child) {
-    @include breakpoint(lg) {
-      margin-right: -$spacing-05;
-    }
-  }
 
   &:not(:first-child) {
     border-left: 1px solid $layer-accent;

--- a/services/web-app/components/catalog-sort/catalog-sort.module.scss
+++ b/services/web-app/components/catalog-sort/catalog-sort.module.scss
@@ -17,6 +17,11 @@
       box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
     }
   }
+
+  // override carbon width to align icon
+  :global(.cds--list-box__menu-icon) {
+    width: auto;
+  }
 }
 
 .grid {

--- a/services/web-app/components/dashboard/dashboard.js
+++ b/services/web-app/components/dashboard/dashboard.js
@@ -21,12 +21,7 @@ export const Dashboard = ({ children, className }) => {
   if (isLg) columns = 3
 
   return (
-    <Grid
-      className={clsx(styles.grid, className)}
-      columns={columns}
-      condensed={!isMd}
-      narrow={isMd}
-    >
+    <Grid className={clsx(styles.grid, className)} columns={columns} condensed>
       {children}
     </Grid>
   )

--- a/services/web-app/components/dashboard/dashboard.module.scss
+++ b/services/web-app/components/dashboard/dashboard.module.scss
@@ -11,23 +11,17 @@
 
 .grid {
   position: relative;
+  grid-gap: 0;
 
-  @include breakpoint-down(md) {
-    grid-gap: 0;
-  }
-}
-
-.column {
   @include breakpoint(md) {
     margin-right: -$spacing-05;
+    margin-left: -$spacing-05;
   }
 }
 
 .subgrid {
-  @include breakpoint-down(md) {
-    margin-right: -$spacing-05;
-    margin-left: -$spacing-05;
-  }
+  margin-right: -$spacing-05;
+  margin-left: -$spacing-05;
 }
 
 .subcolumn {

--- a/services/web-app/pages/assets/[host]/[org]/[repo]/[library]/[ref]/[asset].js
+++ b/services/web-app/pages/assets/[host]/[org]/[repo]/[library]/[ref]/[asset].js
@@ -104,7 +104,7 @@ const Asset = ({ libraryData }) => {
       <PageHeader title={seo.title} pictogram={get(type, `[${assetData.content.type}].icon`)} />
       <PageBreadcrumb items={breadcrumbItems} />
       <Dashboard className={styles.dashboard}>
-        <Column className={dashboardStyles.column}>
+        <Column className={dashboardStyles.column} lg={1}>
           <DashboardItem
             aspectRatio={{ sm: '2x1', md: '1x1', lg: '3x4', xlg: '1x1' }}
             border={['sm']}

--- a/services/web-app/pages/assets/[host]/[org]/[repo]/[library]/[ref]/[asset].module.scss
+++ b/services/web-app/pages/assets/[host]/[org]/[repo]/[library]/[ref]/[asset].module.scss
@@ -6,7 +6,8 @@
 //
 
 .dashboard {
-  margin: $spacing-07 0;
+  margin-top: $spacing-07;
+  margin-bottom: $spacing-07;
 }
 
 .sponsor-icon {

--- a/services/web-app/pages/assets/[host]/[org]/[repo]/[library]/[ref]/index.js
+++ b/services/web-app/pages/assets/[host]/[org]/[repo]/[library]/[ref]/index.js
@@ -72,7 +72,7 @@ const Library = ({ libraryData, params }) => {
       <PageHeader title={seo.title} pictogram={FileBackup} />
       <PageBreadcrumb items={breadcrumbItems} />
       <Dashboard className={styles.dashboard}>
-        <Column className={dashboardStyles.column}>
+        <Column className={dashboardStyles.column} lg={1}>
           <DashboardItem
             aspectRatio={{ sm: '2x1', md: '1x1', lg: '3x4', xlg: '1x1' }}
             border={['sm']}

--- a/services/web-app/pages/assets/[host]/[org]/[repo]/[library]/[ref]/index.module.scss
+++ b/services/web-app/pages/assets/[host]/[org]/[repo]/[library]/[ref]/index.module.scss
@@ -6,7 +6,8 @@
 //
 
 .dashboard {
-  margin: $spacing-07 0;
+  margin-top: $spacing-07;
+  margin-bottom: $spacing-07;
 }
 
 .sponsor-icon {


### PR DESCRIPTION
Closes #273 

#### Testing / reviewing

Everything is grid aware and looks as it did before `narrow` grid support was removed from Carbon React v11.