### PR TITLE
fix(web-app): redirect to previous page on local login

### DIFF
--- a/services/web-app/pages/api/login.js
+++ b/services/web-app/pages/api/login.js
@@ -16,11 +16,6 @@ const login = requireSession().get(
       delete req.session.next
     }
 
-    if (!shouldUseOpenIdStrategy()) {
-      res.redirect('/api/auth-callback')
-      res.end('')
-    }
-
     let refererUrl
     try {
       refererUrl = new URL(req.headers.referer)
@@ -38,6 +33,11 @@ const login = requireSession().get(
       ) {
         req.session.next = refererUrl
       }
+    }
+
+    if (!shouldUseOpenIdStrategy()) {
+      res.redirect('/api/auth-callback')
+      res.end('')
     }
 
     next()


### PR DESCRIPTION
move local auth logic further down because session.next is not being set locally since it's redirecting before it gets there