### PR TITLE
fix: broken link styling asset lp

### DIFF
--- a/services/web-app/pages/assets/index.js
+++ b/services/web-app/pages/assets/index.js
@@ -204,22 +204,26 @@ const PageContent = () => {
           </p>
           <p className={styles.contentCopy}>
             <Link
+              className={styles.link}
               href="https://github.com/carbon-design-system/carbon-platform/blob/main/docs/resource-schemas.md#resource-schemas"
               renderIcon={ArrowRight}
             >
-              <a className={styles.link}>Get started</a>
+              Get started
             </Link>
           </p>
           <h2 className={styles.contentHeading}>Platform roadmap</h2>
           <p className={styles.contentCopy}>
             Progress on the following releases are documented in{' '}
-            <Link href="https://github.com/carbon-design-system/carbon-platform">
-              <a className={styles.link}>GitHub</a>
+            <Link
+              className={styles.link}
+              href="https://github.com/carbon-design-system/carbon-platform"
+            >
+              GitHub
             </Link>
             , along with milestones, estimated dates, and descriptions of high level outcomes. For a
             visual overview of the following releases and their epics, view our roadmap in{' '}
-            <Link href="https://airtable.com/shrshl3XOeeT4Uxq0">
-              <a className={styles.link}>Airtable</a>
+            <Link className={styles.link} href="https://airtable.com/shrshl3XOeeT4Uxq0">
+              Airtable
             </Link>
             .
           </p>

--- a/services/web-app/pages/assets/index/index.module.scss
+++ b/services/web-app/pages/assets/index/index.module.scss
@@ -37,6 +37,7 @@
 .link {
   // override carbon
   font-size: inherit;
+  line-height: inherit;
 }
 
 /**

--- a/services/web-app/pages/assets/index/index.module.scss
+++ b/services/web-app/pages/assets/index/index.module.scss
@@ -35,7 +35,8 @@
 }
 
 .link {
-  @include type-style('body-long-02');
+  // override carbon
+  font-size: inherit;
 }
 
 /**

--- a/services/web-app/pages/assets/index/index.module.scss
+++ b/services/web-app/pages/assets/index/index.module.scss
@@ -34,6 +34,10 @@
   font-weight: 600;
 }
 
+.link {
+  @include type-style('body-long-02');
+}
+
 /**
  * Subheading
  */


### PR DESCRIPTION
The three links on the asset landing page are too small. Upon further review, I found that we were nesting anchor elements. Easy mistake, given how we are using the Carbon `Link` component here, no the Next `Link` component that requires a child anchor element.

#### Changelog

**New**

- NA

**Changed**

- Link styling on asset landing page

**Removed**

- NA

#### Testing / reviewing

Links in asset landing page are now the same size as their surrounding body copy.
