### PR TITLE
non-Canonical Framework Collapsing

### DIFF
--- a/services/web-app/components/catalog/catalog.js
+++ b/services/web-app/components/catalog/catalog.js
@@ -23,6 +23,7 @@ import {
   getCanonicalLibraryId,
   librarySortComparator
 } from '@/utils/schema'
+import { getSlug } from '@/utils/slug'
 import { queryTypes, useQueryState } from '@/utils/use-query-state'
 
 import styles from './catalog.module.scss'
@@ -44,12 +45,11 @@ const assetIsInFilter = (asset, filter) => {
     }
   }
 
-  if (collapseAssetGroups(asset, filter)) {
-    return get(asset, 'library.content.id') === getCanonicalLibraryId(asset)
-  }
-
   return true
 }
+
+const isCanonicalLibAsset = (asset) =>
+  get(asset, 'library.content.id') === getCanonicalLibraryId(asset)
 
 function Catalog({ collection, data, type, filter: defaultFilter = {}, glob = {} }) {
   const [query, setQuery] = useQueryState('q', {
@@ -131,23 +131,45 @@ function Catalog({ collection, data, type, filter: defaultFilter = {}, glob = {}
   })
 
   useEffect(() => {
-    setFilteredAssets(
-      assets
-        .sort(assetSortComparator(sort))
-        .filter((asset) => assetIsInFilter(asset, filter))
-        .filter((asset) => {
-          const { description = '', name = '' } = asset.content
-
-          if (search) {
-            return (
-              (name && name.toLowerCase().includes(search.toLowerCase())) ||
-              (description && description.toLowerCase().includes(search.toLowerCase()))
-            )
+    const skippedAssets = []
+    const assetsWithAppliedFilter = assets
+      .sort(assetSortComparator(sort))
+      .filter((asset) => {
+        if (assetIsInFilter(asset, filter)) {
+          if (collapseAssetGroups(asset, filter)) {
+            const isCanonicalAsset = isCanonicalLibAsset(asset)
+            if (!isCanonicalAsset) skippedAssets.push(asset)
+            return isCanonicalAsset
           }
-
           return true
-        })
+        } else {
+          return false
+        }
+      })
+      .filter((asset) => {
+        const { description = '', name = '' } = asset.content
+
+        if (search) {
+          return (
+            (name && name.toLowerCase().includes(search.toLowerCase())) ||
+            (description && description.toLowerCase().includes(search.toLowerCase()))
+          )
+        }
+
+        return true
+      })
+
+    let assetsNotInCanonical = skippedAssets.filter(
+      (asset) =>
+        !assetsWithAppliedFilter.some(
+          (filteredAsset) => getSlug(filteredAsset.content) === getSlug(asset.content)
+        )
     )
+
+    assetsNotInCanonical = assetsNotInCanonical.filter(
+      (value, index, self) => index === self.findIndex((t) => t.content.id === value.content.id)
+    )
+    setFilteredAssets([...assetsWithAppliedFilter, ...assetsNotInCanonical])
 
     // avoid deep object equality comparison in the effect by using JSON.stringify
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
Closes #347 

Collapses assets even if they're not in the canonical library (see network graph from carbon charts)

Testing
Validate that search, list view and grid view work as expected, that all carbon charts show vanilla-first framework collapsing and network graph shows angular-first framework collapsing