### PR TITLE
refactor(web-app): per-file sass use statements

### DIFF
--- a/services/web-app/components/autolink-header/autolink-header.module.scss
+++ b/services/web-app/components/autolink-header/autolink-header.module.scss
@@ -4,7 +4,10 @@
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
-@use '@carbon/react/scss/motion' as *;
+@use '@carbon/react/scss/motion' as motion;
+@use '@carbon/react/scss/theme' as theme;
+@use '@carbon/react/scss/spacing' as spacing;
+@use '@carbon/react/scss/breakpoint' as breakpoint;
 
 .header {
   position: relative;
@@ -13,7 +16,7 @@
 .anchor {
   opacity: 0;
 
-  transition: opacity $duration-fast-01 $standard-easing;
+  transition: opacity motion.$duration-fast-01 motion.$standard-easing;
 
   &:hover,
   &:active,
@@ -22,26 +25,26 @@
   }
 
   &:focus {
-    outline: 2px solid $focus;
+    outline: 2px solid theme.$focus;
   }
 
   svg {
-    fill: $link-primary;
+    fill: theme.$link-primary;
   }
 }
 
 .left-anchor {
   position: absolute;
   top: 0;
-  left: calc(#{$spacing-06} * -1);
+  left: calc(#{spacing.$spacing-06} * -1);
 }
 
 .right-anchor {
-  margin-left: $spacing-03;
+  margin-left: spacing.$spacing-03;
   white-space: nowrap;
 }
 
-@include breakpoint('md') {
+@include breakpoint.breakpoint('md') {
   .header:hover .anchor {
     opacity: 1;
   }

--- a/services/web-app/components/catalog-filters/catalog-filters.module.scss
+++ b/services/web-app/components/catalog-filters/catalog-filters.module.scss
@@ -1,23 +1,28 @@
-//
-// Copyright IBM Corp. 2021, 2022
-//
-// This source code is licensed under the Apache-2.0 license found in the
-// LICENSE file in the root directory of this source tree.
-//
+/*
+ * Copyright IBM Corp. 2021, 2022
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+@use '@carbon/react/scss/breakpoint' as breakpoint;
+@use '@carbon/react/scss/spacing' as spacing;
+@use '@carbon/react/scss/theme' as theme;
+
 .container {
-  @include breakpoint-down(md) {
+  @include breakpoint.breakpoint-down(md) {
     display: none;
   }
 
   // override carbon margin
   :global(.cds--tag) {
-    margin: $spacing-02;
+    margin: spacing.$spacing-02;
   }
 }
 
 .section {
-  padding: $spacing-03 $spacing-04;
-  margin-right: -$spacing-05;
-  margin-left: -$spacing-05;
-  background: $layer-01;
+  padding: spacing.$spacing-03 spacing.$spacing-04;
+  margin-right: -(spacing.$spacing-05);
+  margin-left: -(spacing.$spacing-05);
+  background: theme.$layer-01;
 }

--- a/services/web-app/components/catalog-item/catalog-item.module.scss
+++ b/services/web-app/components/catalog-item/catalog-item.module.scss
@@ -1,29 +1,38 @@
-//
-// Copyright IBM Corp. 2021, 2022
-//
-// This source code is licensed under the Apache-2.0 license found in the
-// LICENSE file in the root directory of this source tree.
-//
+/*
+ * Copyright IBM Corp. 2021, 2022
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 @use 'sass:math';
+@use '@carbon/react/scss/breakpoint' as breakpoint;
+@use '@carbon/react/scss/motion' as motion;
+@use '@carbon/motion/scss' as motion-utils;
+@use '@carbon/react/scss/spacing' as spacing;
+@use '@carbon/react/scss/theme' as theme;
+@use '@carbon/react/scss/type' as type;
+
+@use '~styles/mixins' as mixins;
 
 .column {
   position: relative;
-  transition: border-color $fast-02 carbon--motion(standard, productive);
+  transition: border-color motion.$duration-fast-02
+    motion-utils.carbon--motion(standard, productive);
 
   &:not(:first-child) {
-    @include breakpoint(md) {
-      border-left: 1px solid $layer-accent;
+    @include breakpoint.breakpoint(md) {
+      border-left: 1px solid theme.$layer-accent;
     }
 
     .anchor:hover &,
     .anchor:focus & {
-      border-color: $border-subtle-selected;
+      border-color: theme.$border-subtle-selected;
     }
   }
 
   &--image {
-    @include breakpoint-down(md) {
+    @include breakpoint.breakpoint-down(md) {
       display: none;
     }
   }
@@ -31,66 +40,67 @@
 
 .anchor {
   display: block;
-  background: $layer-01;
+  background: theme.$layer-01;
   text-decoration: none;
-  transition: background $fast-02 carbon--motion(standard, productive);
+  transition: background motion.$duration-fast-02 motion-utils.carbon--motion(standard, productive);
 
   &:hover,
   &:focus {
-    background: $layer-hover;
+    background: theme.$layer-hover;
   }
 
   &:active {
-    outline: 2px solid $focus;
+    outline: 2px solid theme.$focus;
     outline-offset: -2px;
   }
 
   &:not(.anchor--grid) {
-    border-top: 1px solid $layer-accent;
+    border-top: 1px solid theme.$layer-accent;
   }
 }
 
 .content {
-  padding: $spacing-05;
-  @include breakpoint(lg) {
+  padding: spacing.$spacing-05;
+  @include breakpoint.breakpoint(lg) {
     padding-right: 0;
   }
 
   .anchor--grid & {
-    border-top: 1px solid $layer-accent;
+    border-top: 1px solid theme.$layer-accent;
     margin-right: 0;
-    transition: border-color $fast-02 carbon--motion(standard, productive);
+    transition: border-color motion.$duration-fast-02
+      motion-utils.carbon--motion(standard, productive);
   }
 
   .anchor--grid:hover &,
   .anchor--grid:focus & {
-    border-color: $border-subtle-selected;
+    border-color: theme.$border-subtle-selected;
   }
 }
 
 .library {
-  color: $text-primary;
-  @include line-clamp(1);
-  @include type-style('label-01');
+  color: theme.$text-primary;
+  @include mixins.line-clamp(1);
+  @include type.type-style('label-01');
 }
 
 .name {
-  color: $text-primary;
-  @include line-clamp(2);
-  @include type-style('productive-heading-02');
+  color: theme.$text-primary;
+  @include mixins.line-clamp(2);
+  @include type.type-style('productive-heading-02');
 
   .anchor--grid & {
-    @include breakpoint-down(xlg) {
-      @include line-clamp(1);
+    @include breakpoint.breakpoint-down(xlg) {
+      @include mixins.line-clamp(1);
     }
   }
 }
 
 .description {
-  margin-top: $spacing-02;
-  color: $text-primary;
-  @include line-clamp(3);
-  @include type-style('body-short-01');
+  margin-top: spacing.$spacing-02;
+  color: theme.$text-primary;
+  @include mixins.line-clamp(3);
+  @include type.type-style('body-short-01');
 
   .anchor--grid & {
     display: none;
@@ -99,33 +109,33 @@
 
 .icon {
   position: absolute;
-  right: $spacing-04;
-  bottom: $spacing-04;
+  right: spacing.$spacing-04;
+  bottom: spacing.$spacing-04;
   display: block;
-  width: $spacing-09;
-  height: $spacing-09;
-  border: 1px solid $border-subtle;
-  background: $layer-01;
+  width: spacing.$spacing-09;
+  height: spacing.$spacing-09;
+  border: 1px solid theme.$border-subtle;
+  background: theme.$layer-01;
   border-radius: 100%;
-  color: $icon-primary;
-  transition: all $fast-02 carbon--motion(standard, productive);
-  @include breakpoint(xlg) {
-    width: $spacing-09 + $spacing-03;
-    height: $spacing-09 + $spacing-03;
+  color: theme.$icon-primary;
+  transition: all motion.$duration-fast-02 motion-utils.carbon--motion(standard, productive);
+  @include breakpoint.breakpoint(xlg) {
+    width: spacing.$spacing-09 + spacing.$spacing-03;
+    height: spacing.$spacing-09 + spacing.$spacing-03;
   }
 
   .anchor--grid & {
-    top: math.div(-$spacing-09, 2);
+    top: math.div(-(spacing.$spacing-09), 2);
     bottom: auto;
-    @include breakpoint(xlg) {
-      top: math.div(-$spacing-09 - $spacing-03, 2);
+    @include breakpoint.breakpoint(xlg) {
+      top: math.div(-(spacing.$spacing-09) - spacing.$spacing-03, 2);
     }
   }
 
   .anchor:hover &,
   .anchor:focus & {
-    border-color: $border-subtle-selected;
-    background: $layer-hover;
+    border-color: theme.$border-subtle-selected;
+    background: theme.$layer-hover;
   }
 }
 
@@ -135,7 +145,7 @@
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  transition: opacity $fast-02 carbon--motion(standard, productive);
+  transition: opacity motion.$duration-fast-02 motion-utils.carbon--motion(standard, productive);
 }
 
 .icon-sponsor {
@@ -158,30 +168,30 @@
 
 .framework {
   position: absolute;
-  top: $spacing-04;
-  right: $spacing-04;
-  transition: background $fast-02 carbon--motion(standard, productive);
+  top: spacing.$spacing-04;
+  right: spacing.$spacing-04;
+  transition: background motion.$duration-fast-02 motion-utils.carbon--motion(standard, productive);
 
   .anchor--grid & {
     top: auto;
-    bottom: $spacing-04;
+    bottom: spacing.$spacing-04;
   }
 
   .anchor:hover &,
   .anchor:focus & {
-    background: $border-subtle-selected;
+    background: theme.$border-subtle-selected;
   }
 }
 
 .meta {
-  margin-top: $spacing-02;
-  color: $text-secondary;
-  @include type-style('label-01');
+  margin-top: spacing.$spacing-02;
+  color: theme.$text-secondary;
+  @include type.type-style('label-01');
 
   &--absolute {
     position: absolute;
-    bottom: $spacing-04;
-    left: $spacing-04;
+    bottom: spacing.$spacing-04;
+    left: spacing.$spacing-04;
   }
 }
 
@@ -189,14 +199,14 @@
   display: inline;
 
   &:not(:first-child) {
-    margin-left: $spacing-03;
+    margin-left: spacing.$spacing-03;
   }
 }
 
 .meta-icon {
   position: relative;
   top: 3px;
-  margin-right: $spacing-02;
+  margin-right: spacing.$spacing-02;
 }
 
 .image {

--- a/services/web-app/components/catalog-item/catalog-item.module.scss
+++ b/services/web-app/components/catalog-item/catalog-item.module.scss
@@ -8,7 +8,6 @@
 @use 'sass:math';
 @use '@carbon/react/scss/breakpoint' as breakpoint;
 @use '@carbon/react/scss/motion' as motion;
-@use '@carbon/motion/scss' as motion-utils;
 @use '@carbon/react/scss/spacing' as spacing;
 @use '@carbon/react/scss/theme' as theme;
 @use '@carbon/react/scss/type' as type;
@@ -17,8 +16,7 @@
 
 .column {
   position: relative;
-  transition: border-color motion.$duration-fast-02
-    motion-utils.carbon--motion(standard, productive);
+  transition: border-color motion.$duration-fast-02 motion.motion(standard, productive);
 
   &:not(:first-child) {
     @include breakpoint.breakpoint(md) {
@@ -42,7 +40,7 @@
   display: block;
   background: theme.$layer-01;
   text-decoration: none;
-  transition: background motion.$duration-fast-02 motion-utils.carbon--motion(standard, productive);
+  transition: background motion.$duration-fast-02 motion.motion(standard, productive);
 
   &:hover,
   &:focus {
@@ -68,8 +66,7 @@
   .anchor--grid & {
     border-top: 1px solid theme.$layer-accent;
     margin-right: 0;
-    transition: border-color motion.$duration-fast-02
-      motion-utils.carbon--motion(standard, productive);
+    transition: border-color motion.$duration-fast-02 motion.motion(standard, productive);
   }
 
   .anchor--grid:hover &,
@@ -118,7 +115,7 @@
   background: theme.$layer-01;
   border-radius: 100%;
   color: theme.$icon-primary;
-  transition: all motion.$duration-fast-02 motion-utils.carbon--motion(standard, productive);
+  transition: all motion.$duration-fast-02 motion.motion(standard, productive);
   @include breakpoint.breakpoint(xlg) {
     width: spacing.$spacing-09 + spacing.$spacing-03;
     height: spacing.$spacing-09 + spacing.$spacing-03;
@@ -145,7 +142,7 @@
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  transition: opacity motion.$duration-fast-02 motion-utils.carbon--motion(standard, productive);
+  transition: opacity motion.$duration-fast-02 motion.motion(standard, productive);
 }
 
 .icon-sponsor {
@@ -170,7 +167,7 @@
   position: absolute;
   top: spacing.$spacing-04;
   right: spacing.$spacing-04;
-  transition: background motion.$duration-fast-02 motion-utils.carbon--motion(standard, productive);
+  transition: background motion.$duration-fast-02 motion.motion(standard, productive);
 
   .anchor--grid & {
     top: auto;

--- a/services/web-app/components/catalog-list/catalog-list.module.scss
+++ b/services/web-app/components/catalog-list/catalog-list.module.scss
@@ -1,48 +1,54 @@
-//
-// Copyright IBM Corp. 2021, 2022
-//
-// This source code is licensed under the Apache-2.0 license found in the
-// LICENSE file in the root directory of this source tree.
-//
+/*
+ * Copyright IBM Corp. 2021, 2022
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+@use '@carbon/react/scss/breakpoint' as breakpoint;
+@use '@carbon/react/scss/spacing' as spacing;
+@use '@carbon/react/scss/theme' as theme;
+@use '@carbon/react/scss/type' as type;
+
 .container {
-  background: $background;
-  @include breakpoint(md) {
-    margin-right: -$spacing-05;
-    margin-left: -$spacing-05;
+  background: theme.$background;
+  @include breakpoint.breakpoint(md) {
+    margin-right: -(spacing.$spacing-05);
+    margin-left: -(spacing.$spacing-05);
   }
 
   &--grid {
-    margin-top: $spacing-05;
-    margin-bottom: $spacing-05;
-    row-gap: $spacing-05;
+    margin-top: (spacing.$spacing-05);
+    margin-bottom: (spacing.$spacing-05);
+    row-gap: (spacing.$spacing-05);
     --cds-grid-gutter: 1rem;
-    @include breakpoint(md) {
+    @include breakpoint.breakpoint(md) {
       margin-right: 0;
     }
   }
 }
 
 .copy {
-  margin-top: $spacing-09;
-  margin-bottom: $spacing-09;
-  @include breakpoint-down(md) {
-    padding-right: $spacing-05;
-    padding-left: $spacing-05;
+  margin-top: spacing.$spacing-09;
+  margin-bottom: spacing.$spacing-09;
+  @include breakpoint.breakpoint-down(md) {
+    padding-right: (spacing.$spacing-05);
+    padding-left: (spacing.$spacing-05);
   }
 
   &--grid {
-    padding-right: $spacing-05;
-    padding-left: $spacing-05;
-    margin-top: ($spacing-09 - $spacing-05);
-    margin-bottom: ($spacing-09 - $spacing-05);
+    padding-right: (spacing.$spacing-05);
+    padding-left: (spacing.$spacing-05);
+    margin-top: (spacing.$spacing-09 - (spacing.$spacing-05));
+    margin-bottom: (spacing.$spacing-09 - (spacing.$spacing-05));
   }
 }
 
 .heading {
-  @include type-style('productive-heading-04');
+  @include type.type-style('productive-heading-04');
 }
 
 .paragraph {
-  margin-top: $spacing-05;
-  @include type-style('body-short-01');
+  margin-top: (spacing.$spacing-05);
+  @include type.type-style('body-short-01');
 }

--- a/services/web-app/components/catalog-multislect-filter/catalog-multiselect-filter.module.scss
+++ b/services/web-app/components/catalog-multislect-filter/catalog-multiselect-filter.module.scss
@@ -1,38 +1,47 @@
-//
-// Copyright IBM Corp. 2021, 2022
-//
-// This source code is licensed under the Apache-2.0 license found in the
-// LICENSE file in the root directory of this source tree.
-//
+/*
+ * Copyright IBM Corp. 2021, 2022
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+@use '@carbon/react/scss/breakpoint' as breakpoint;
+@use '@carbon/react/scss/motion' as motion;
+@use '@carbon/motion/scss' as motion-utils;
+@use '@carbon/react/scss/spacing' as spacing;
+@use '@carbon/react/scss/theme' as theme;
+@use '@carbon/react/scss/type' as type;
+
 .container {
   width: 100%;
-  background: $background;
+  background: theme.$background;
 }
 
 .trigger {
   position: relative;
   width: 100%;
-  height: $spacing-09;
-  padding: 0 $spacing-05;
+  height: spacing.$spacing-09;
+  padding: 0 spacing.$spacing-05;
   border-top: 0;
   border-right: 0;
-  border-bottom: 1px solid $border-strong;
+  border-bottom: 1px solid theme.$border-strong;
   border-left: 0;
-  background-color: $field;
-  color: $text-primary;
+  background-color: theme.$field;
+  color: theme.$text-primary;
   cursor: pointer;
-  transition: background-color $fast-01 carbon--motion(standard, productive),
-    outline $fast-01 carbon--motion(standard, productive);
-  @include type-style('body-short-01');
+  transition: background-color motion.$duration-fast-01
+      motion-utils.carbon--motion(standard, productive),
+    outline motion.$duration-fast-01 motion-utils.carbon--motion(standard, productive);
+  @include type.type-style('body-short-01');
 
   &:focus,
   &:active {
-    outline: 2px solid $focus;
+    outline: 2px solid theme.$focus;
     outline-offset: -2px;
   }
 
   &:hover {
-    background-color: $layer-hover;
+    background-color: theme.$layer-hover;
   }
 }
 
@@ -41,7 +50,7 @@
   width: 100%;
   align-items: center;
   justify-content: center;
-  @include breakpoint(md) {
+  @include breakpoint.breakpoint(md) {
     justify-content: space-between;
   }
 }
@@ -52,12 +61,12 @@
 }
 
 .tag {
-  margin-right: $spacing-03;
+  margin-right: spacing.$spacing-03;
 }
 
 .icon {
-  fill: $icon-primary;
-  transition: transform $fast-01 carbon--motion(standard, productive);
+  fill: theme.$icon-primary;
+  transition: transform motion.$duration-fast-01 motion-utils.carbon--motion(standard, productive);
 
   &--rotate {
     transform: rotate(180deg);
@@ -66,45 +75,45 @@
 
 .count {
   position: absolute;
-  top: $spacing-01;
-  right: $spacing-01;
+  top: spacing.$spacing-01;
+  right: spacing.$spacing-01;
   display: inline-block;
-  min-width: $spacing-05 + $spacing-02;
-  padding-right: $spacing-02;
-  padding-left: $spacing-02;
-  border: $spacing-01 solid $text-inverse;
-  background: $border-inverse;
-  border-radius: $spacing-09;
-  color: $text-inverse;
-  @include type-style('label-01');
+  min-width: spacing.$spacing-05 + spacing.$spacing-02;
+  padding-right: spacing.$spacing-02;
+  padding-left: spacing.$spacing-02;
+  border: spacing.$spacing-01 solid theme.$text-inverse;
+  background: theme.$border-inverse;
+  border-radius: spacing.$spacing-09;
+  color: theme.$text-inverse;
+  @include type.type-style('label-01');
 
   // override type scale
-  line-height: $spacing-05;
+  line-height: spacing.$spacing-05;
 }
 
 .content {
   width: 100vw;
   max-width: none;
-  @include breakpoint(md) {
+  @include breakpoint.breakpoint(md) {
     // span two columns, where each column has a 1px gutter
     width: calc(200% + 2px);
   }
   // span three columns, where each column has a 1px gutter
-  @include breakpoint(lg) {
+  @include breakpoint.breakpoint(lg) {
     width: calc(300% + 3px);
   }
 }
 
 .grid {
   position: relative;
-  padding: $spacing-03 0;
+  padding: spacing.$spacing-03 0;
 
   &::before,
   &::after {
     position: absolute;
     width: 100%;
-    height: $spacing-06;
-    background: $layer-01;
+    height: spacing.$spacing-06;
+    background: theme.$layer-01;
     content: '';
   }
 
@@ -118,19 +127,19 @@
 }
 
 .column {
-  padding: $spacing-05;
-  border-top: 1px solid $layer-accent;
-  @include breakpoint(md) {
+  padding: spacing.$spacing-05;
+  border-top: 1px solid theme.$layer-accent;
+  @include breakpoint.breakpoint(md) {
     border-top: 0;
-    border-left: 1px solid $layer-accent;
+    border-left: 1px solid theme.$layer-accent;
 
     &:nth-child(2n + 1) {
       border-left: 0;
     }
   }
-  @include breakpoint(lg) {
+  @include breakpoint.breakpoint(lg) {
     &:nth-child(2n + 1) {
-      border-left: 1px solid $layer-accent;
+      border-left: 1px solid theme.$layer-accent;
     }
 
     &:nth-child(3n + 1) {
@@ -144,13 +153,13 @@
 }
 
 .heading {
-  margin-bottom: $spacing-05;
-  color: $text-secondary;
-  @include type-style('body-short-01');
+  margin-bottom: spacing.$spacing-05;
+  color: theme.$text-secondary;
+  @include type.type-style('body-short-01');
 }
 
 .list {
-  margin: -$spacing-02;
+  margin: -(spacing.$spacing-02);
 
   &-item {
     display: inline-block;

--- a/services/web-app/components/catalog-multislect-filter/catalog-multiselect-filter.module.scss
+++ b/services/web-app/components/catalog-multislect-filter/catalog-multiselect-filter.module.scss
@@ -7,7 +7,6 @@
 
 @use '@carbon/react/scss/breakpoint' as breakpoint;
 @use '@carbon/react/scss/motion' as motion;
-@use '@carbon/motion/scss' as motion-utils;
 @use '@carbon/react/scss/spacing' as spacing;
 @use '@carbon/react/scss/theme' as theme;
 @use '@carbon/react/scss/type' as type;
@@ -29,9 +28,8 @@
   background-color: theme.$field;
   color: theme.$text-primary;
   cursor: pointer;
-  transition: background-color motion.$duration-fast-01
-      motion-utils.carbon--motion(standard, productive),
-    outline motion.$duration-fast-01 motion-utils.carbon--motion(standard, productive);
+  transition: background-color motion.$duration-fast-01 motion.motion(standard, productive),
+    outline motion.$duration-fast-01 motion.motion(standard, productive);
   @include type.type-style('body-short-01');
 
   &:focus,
@@ -66,7 +64,7 @@
 
 .icon {
   fill: theme.$icon-primary;
-  transition: transform motion.$duration-fast-01 motion-utils.carbon--motion(standard, productive);
+  transition: transform motion.$duration-fast-01 motion.motion(standard, productive);
 
   &--rotate {
     transform: rotate(180deg);

--- a/services/web-app/components/catalog-pagination/catalog-pagination.module.scss
+++ b/services/web-app/components/catalog-pagination/catalog-pagination.module.scss
@@ -1,13 +1,17 @@
-//
-// Copyright IBM Corp. 2021, 2022
-//
-// This source code is licensed under the Apache-2.0 license found in the
-// LICENSE file in the root directory of this source tree.
-//
+/*
+ * Copyright IBM Corp. 2021, 2022
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+@use '@carbon/react/scss/breakpoint' as breakpoint;
+@use '@carbon/react/scss/spacing' as spacing;
+
 .container {
-  margin-bottom: $spacing-07;
-  @include breakpoint(md) {
-    margin-right: -$spacing-05;
-    margin-left: -$spacing-05;
+  margin-bottom: spacing.$spacing-07;
+  @include breakpoint.breakpoint(md) {
+    margin-right: -(spacing.$spacing-05);
+    margin-left: -(spacing.$spacing-05);
   }
 }

--- a/services/web-app/components/catalog-results/catalog-results.module.scss
+++ b/services/web-app/components/catalog-results/catalog-results.module.scss
@@ -1,20 +1,26 @@
-//
-// Copyright IBM Corp. 2021, 2022
-//
-// This source code is licensed under the Apache-2.0 license found in the
-// LICENSE file in the root directory of this source tree.
-//
+/*
+ * Copyright IBM Corp. 2021, 2022
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+@use '@carbon/react/scss/breakpoint' as breakpoint;
+@use '@carbon/react/scss/spacing' as spacing;
+@use '@carbon/react/scss/theme' as theme;
+@use '@carbon/react/scss/type' as type;
+
 .container {
-  margin: $spacing-07 0 $spacing-05;
-  @include breakpoint(md) {
-    margin-right: -$spacing-05;
-    margin-left: -$spacing-05;
+  margin: spacing.$spacing-07 0 spacing.$spacing-05;
+  @include breakpoint.breakpoint(md) {
+    margin-right: -(spacing.$spacing-05);
+    margin-left: -(spacing.$spacing-05);
   }
 }
 
 .results {
-  padding-bottom: $spacing-03;
-  padding-left: $spacing-05;
-  border-bottom: 1px solid $layer-accent;
-  @include type-style('productive-heading-02');
+  padding-bottom: spacing.$spacing-03;
+  padding-left: spacing.$spacing-05;
+  border-bottom: 1px solid theme.$layer-accent;
+  @include type.type-style('productive-heading-02');
 }

--- a/services/web-app/components/catalog-search/catalog-search.module.scss
+++ b/services/web-app/components/catalog-search/catalog-search.module.scss
@@ -1,22 +1,27 @@
-//
-// Copyright IBM Corp. 2021, 2022
-//
-// This source code is licensed under the Apache-2.0 license found in the
-// LICENSE file in the root directory of this source tree.
-//
+/*
+ * Copyright IBM Corp. 2021, 2022
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+@use '@carbon/react/scss/breakpoint' as breakpoint;
+@use '@carbon/react/scss/spacing' as spacing;
+@use '@carbon/react/scss/theme' as theme;
+
 .container {
   // position above CatalogSort
   // override carbon grid gutter
   position: sticky;
   z-index: 2;
-  top: $spacing-09 + $spacing-05;
+  top: spacing.$spacing-09 + spacing.$spacing-05;
   --cds-grid-gutter: 0;
-  @include breakpoint-down(md) {
-    top: $spacing-09;
+  @include breakpoint.breakpoint-down(md) {
+    top: spacing.$spacing-09;
   }
-  @include breakpoint(md) {
-    margin-right: -$spacing-05;
-    margin-left: -$spacing-05;
+  @include breakpoint.breakpoint(md) {
+    margin-right: -(spacing.$spacing-05);
+    margin-left: -(spacing.$spacing-05);
   }
 
   // gray background above search when scrolled
@@ -24,9 +29,9 @@
     position: absolute;
     right: 0;
     bottom: 100%;
-    left: -$spacing-05;
-    height: $spacing-05;
-    background: $background;
+    left: -(spacing.$spacing-05);
+    height: spacing.$spacing-05;
+    background: theme.$background;
     content: '';
   }
 
@@ -37,26 +42,26 @@
 
   :global(.cds--search--lg .cds--search-input),
   :global(.cds--search--lg .cds--search-close) {
-    height: $spacing-09;
+    height: spacing.$spacing-09;
   }
 }
 
 .column {
   &:not(:first-child) {
-    border-left: 1px solid $layer-accent;
+    border-left: 1px solid theme.$layer-accent;
   }
 }
 
 .column-search {
-  @include breakpoint-down(md) {
+  @include breakpoint.breakpoint-down(md) {
     display: flex;
   }
 }
 
 .filter {
-  @include breakpoint-down(md) {
-    flex-basis: $spacing-09;
+  @include breakpoint.breakpoint-down(md) {
+    flex-basis: spacing.$spacing-09;
     flex-shrink: 0;
-    border-left: 1px solid $layer-accent;
+    border-left: 1px solid theme.$layer-accent;
   }
 }

--- a/services/web-app/components/catalog-sort/catalog-sort.module.scss
+++ b/services/web-app/components/catalog-sort/catalog-sort.module.scss
@@ -1,16 +1,21 @@
-//
-// Copyright IBM Corp. 2021, 2022
-//
-// This source code is licensed under the Apache-2.0 license found in the
-// LICENSE file in the root directory of this source tree.
-//
+/*
+ * Copyright IBM Corp. 2021, 2022
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+@use '@carbon/react/scss/breakpoint' as breakpoint;
+@use '@carbon/react/scss/spacing' as spacing;
+@use '@carbon/react/scss/theme' as theme;
+
 .container {
-  @include breakpoint(md) {
+  @include breakpoint.breakpoint(md) {
     position: sticky;
     z-index: 1;
-    top: $spacing-09 + $spacing-05 + $spacing-09;
-    margin-right: -$spacing-05;
-    margin-left: -$spacing-05;
+    top: spacing.$spacing-09 + spacing.$spacing-05 + spacing.$spacing-09;
+    margin-right: -(spacing.$spacing-05);
+    margin-left: -(spacing.$spacing-05);
 
     &--sticky {
       box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
@@ -25,20 +30,20 @@
 
 .grid {
   // override carbon grid gutter
-  background: $layer-01;
+  background: theme.$layer-01;
   --cds-grid-gutter: 0;
 }
 
 .column {
-  background: $layer-01;
+  background: theme.$layer-01;
 
   &:not(:first-child) {
-    border-left: 1px solid $layer-accent;
+    border-left: 1px solid theme.$layer-accent;
   }
 
   &--switcher {
     text-align: right;
-    @include breakpoint-down(lg) {
+    @include breakpoint.breakpoint-down(lg) {
       display: none;
     }
   }
@@ -49,12 +54,12 @@
   position: relative;
   display: flex;
   width: 100%;
-  padding-left: $spacing-05;
+  padding-left: spacing.$spacing-05;
   grid-gap: 0;
 
   // overide carbon color
   :global(.cds--label) {
-    color: $text-primary;
+    color: theme.$text-primary;
   }
 
   // overide carbon position, flex-grow
@@ -72,8 +77,8 @@
 
 .button {
   // override carbon because `lg` isn't supported
-  width: $spacing-09;
-  height: $spacing-09;
+  width: spacing.$spacing-09;
+  height: spacing.$spacing-09;
 
   // override icon alignment because the IconButton only supports `sm` size currently
   &:global(.cds--btn--sm) {

--- a/services/web-app/components/catalog/catalog.module.scss
+++ b/services/web-app/components/catalog/catalog.module.scss
@@ -1,9 +1,12 @@
-//
-// Copyright IBM Corp. 2021, 2022
-//
-// This source code is licensed under the Apache-2.0 license found in the
-// LICENSE file in the root directory of this source tree.
-//
+/*
+ * Copyright IBM Corp. 2021, 2022
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+@use '@carbon/react/scss/spacing' as spacing;
+
 .search {
-  margin-top: $spacing-07;
+  margin-top: spacing.$spacing-07;
 }

--- a/services/web-app/components/dashboard/dashboard-item.module.scss
+++ b/services/web-app/components/dashboard/dashboard-item.module.scss
@@ -6,7 +6,6 @@
  */
 
 @use '@carbon/react/scss/motion' as motion;
-@use '@carbon/motion/scss' as motion-utils;
 @use '@carbon/react/scss/spacing' as spacing;
 @use '@carbon/react/scss/theme' as theme;
 
@@ -22,7 +21,7 @@
   padding: spacing.$spacing-05;
   margin-right: 1px;
   background: theme.$layer-01;
-  transition: background motion.$duration-fast-02 motion-utils.carbon--motion(standard, productive);
+  transition: background motion.$duration-fast-02 motion.motion(standard, productive);
 
   &--border {
     outline: 1px solid theme.$background;

--- a/services/web-app/components/dashboard/dashboard-item.module.scss
+++ b/services/web-app/components/dashboard/dashboard-item.module.scss
@@ -1,9 +1,15 @@
-//
-// Copyright IBM Corp. 2022, 2022
-//
-// This source code is licensed under the Apache-2.0 license found in the
-// LICENSE file in the root directory of this source tree.
-//
+/*
+ * Copyright IBM Corp. 2022, 2022
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+@use '@carbon/react/scss/motion' as motion;
+@use '@carbon/motion/scss' as motion-utils;
+@use '@carbon/react/scss/spacing' as spacing;
+@use '@carbon/react/scss/theme' as theme;
+
 .anchor {
   display: block;
   text-decoration: none;
@@ -13,28 +19,28 @@
   position: relative;
   display: block;
   height: 100%;
-  padding: $spacing-05;
+  padding: spacing.$spacing-05;
   margin-right: 1px;
-  background: $layer-01;
-  transition: background $fast-02 carbon--motion(standard, productive);
+  background: theme.$layer-01;
+  transition: background motion.$duration-fast-02 motion-utils.carbon--motion(standard, productive);
 
   &--border {
-    outline: 1px solid $background;
+    outline: 1px solid theme.$background;
     outline-offset: 0;
   }
 
   &--spacer {
-    background: $background;
+    background: theme.$background;
   }
 
   .anchor & {
     &:hover,
     &:focus {
-      background: $layer-hover;
+      background: theme.$layer-hover;
     }
 
     &:active {
-      outline: 2px solid $border-interactive;
+      outline: 2px solid theme.$border-interactive;
       outline-offset: -2px;
     }
   }

--- a/services/web-app/components/dashboard/dashboard.module.scss
+++ b/services/web-app/components/dashboard/dashboard.module.scss
@@ -1,9 +1,14 @@
-//
-// Copyright IBM Corp. 2022, 2022
-//
-// This source code is licensed under the Apache-2.0 license found in the
-// LICENSE file in the root directory of this source tree.
-//
+/*
+ * Copyright IBM Corp. 2022, 2022
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+@use '@carbon/react/scss/breakpoint' as breakpoint;
+@use '@carbon/react/scss/spacing' as spacing;
+@use '@carbon/react/scss/theme' as theme;
+@use '@carbon/react/scss/type' as type;
 
 /*
  * Layout
@@ -13,20 +18,20 @@
   position: relative;
   grid-gap: 0;
 
-  @include breakpoint(md) {
-    margin-right: -$spacing-05;
-    margin-left: -$spacing-05;
+  @include breakpoint.breakpoint(md) {
+    margin-right: -(spacing.$spacing-05);
+    margin-left: -(spacing.$spacing-05);
   }
 }
 
 .subgrid {
-  margin-right: -$spacing-05;
-  margin-left: -$spacing-05;
+  margin-right: -(spacing.$spacing-05);
+  margin-left: -(spacing.$spacing-05);
 }
 
 .subcolumn {
-  @include breakpoint-down(md) {
-    padding-left: $spacing-05;
+  @include breakpoint.breakpoint-down(md) {
+    padding-left: spacing.$spacing-05;
   }
 
   &--links {
@@ -41,16 +46,16 @@
 
 .position-bottom-left {
   position: absolute;
-  bottom: $spacing-04;
-  left: $spacing-04;
-  color: $text-primary;
+  bottom: spacing.$spacing-04;
+  left: spacing.$spacing-04;
+  color: theme.$text-primary;
 }
 
 .position-bottom-right {
   position: absolute;
-  right: $spacing-04;
-  bottom: $spacing-04;
-  color: $text-primary;
+  right: spacing.$spacing-04;
+  bottom: spacing.$spacing-04;
+  color: theme.$text-primary;
 }
 
 /*
@@ -58,34 +63,34 @@
  */
 
 .label {
-  padding-bottom: $spacing-01;
-  color: $text-secondary;
-  @include type-style('body-short-01');
+  padding-bottom: spacing.$spacing-01;
+  color: theme.$text-secondary;
+  @include type.type-style('body-short-01');
 
   &--large {
-    color: $text-primary;
-    @include type-style('expressive-heading-04');
+    color: theme.$text-primary;
+    @include type.type-style('expressive-heading-04');
   }
 }
 
 .meta {
-  padding-bottom: $spacing-06;
-  color: $text-primary;
-  @include type-style('body-short-02');
+  padding-bottom: spacing.$spacing-06;
+  color: theme.$text-primary;
+  @include type.type-style('body-short-02');
 }
 
 .meta-link {
-  color: $link-primary;
+  color: theme.$link-primary;
   text-decoration: none;
-  @include type-style('body-short-02');
+  @include type.type-style('body-short-02');
 
   &:hover,
   &:focus {
-    color: $link-primary-hover;
+    color: theme.$link-primary-hover;
     text-decoration: underline;
   }
 
   &--large {
-    @include type-style('expressive-heading-04');
+    @include type.type-style('expressive-heading-04');
   }
 }

--- a/services/web-app/components/footer/footer.module.scss
+++ b/services/web-app/components/footer/footer.module.scss
@@ -1,39 +1,43 @@
-//
-// Copyright IBM Corp. 2021, 2022
-//
-// This source code is licensed under the Apache-2.0 license found in the
-// LICENSE file in the root directory of this source tree.
-//
+/*
+ * Copyright IBM Corp. 2021, 2022
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
-@import '@carbon/colors/scss/colors';
+@use '@carbon/react/scss/breakpoint' as breakpoint;
+@use '@carbon/react/scss/colors' as colors;
+@use '@carbon/react/scss/spacing' as spacing;
+@use '@carbon/react/scss/theme' as theme;
+@use '@carbon/react/scss/type' as type;
 
 .container {
-  background: $black-100;
+  background: colors.$black-100;
 }
 
 .footer {
   margin: 0;
-  @include type-style('body-long-01');
+  @include type.type-style('body-long-01');
 
-  @include breakpoint-down(md) {
-    padding: 0 $spacing-05;
+  @include breakpoint.breakpoint-down(md) {
+    padding: 0 spacing.$spacing-05;
   }
 }
 
 .text {
-  @include type-style('body-long-01');
+  @include type.type-style('body-long-01');
 
-  color: $text-primary;
+  color: theme.$text-primary;
 }
 
 .link {
-  color: $text-primary;
+  color: theme.$text-primary;
   text-decoration: underline;
 }
 
 .list-link {
   display: block;
-  margin-bottom: $spacing-02;
+  margin-bottom: spacing.$spacing-02;
   text-decoration: none;
 
   &:hover {
@@ -42,16 +46,16 @@
 }
 
 .column {
-  padding-top: $spacing-06;
-  padding-bottom: $spacing-09;
-  border-top: 1px solid $border-strong-01;
+  padding-top: spacing.$spacing-06;
+  padding-bottom: spacing.$spacing-09;
+  border-top: 1px solid theme.$border-strong-01;
 
-  @include breakpoint(md) {
+  @include breakpoint.breakpoint(md) {
     border-top: 0;
-    margin-bottom: $spacing-12;
+    margin-bottom: spacing.$spacing-12;
   }
 }
 
 .logo {
-  padding-bottom: $spacing-07;
+  padding-bottom: spacing.$spacing-07;
 }

--- a/services/web-app/components/framework-icon/framework-icon.module.scss
+++ b/services/web-app/components/framework-icon/framework-icon.module.scss
@@ -1,27 +1,32 @@
-//
-// Copyright IBM Corp. 2021, 2022
-//
-// This source code is licensed under the Apache-2.0 license found in the
-// LICENSE file in the root directory of this source tree.
-//
+/*
+ * Copyright IBM Corp. 2021, 2022
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+@use '@carbon/react/scss/spacing' as spacing;
+@use '@carbon/react/scss/theme' as theme;
+@use '@carbon/react/scss/type' as type;
+
 .container {
   display: flex;
-  min-width: $spacing-06;
-  height: $spacing-06;
+  min-width: spacing.$spacing-06;
+  height: spacing.$spacing-06;
   align-items: center;
   justify-content: center;
-  padding: $spacing-02;
-  background: $layer-accent;
-  border-radius: $spacing-06;
-  color: $icon-primary;
+  padding: spacing.$spacing-02;
+  background: theme.$layer-accent;
+  border-radius: spacing.$spacing-06;
+  color: theme.$icon-primary;
 }
 
 .icon {
-  width: $spacing-05;
-  height: $spacing-05;
+  width: spacing.$spacing-05;
+  height: spacing.$spacing-05;
 }
 
 .text {
-  margin: 0 $spacing-02;
-  @include type-style('label-01');
+  margin: 0 spacing.$spacing-02;
+  @include type.type-style('label-01');
 }

--- a/services/web-app/components/hero/hero.module.scss
+++ b/services/web-app/components/hero/hero.module.scss
@@ -1,17 +1,22 @@
-//
-// Copyright IBM Corp. 2022, 2022
-//
-// This source code is licensed under the Apache-2.0 license found in the
-// LICENSE file in the root directory of this source tree.
-//
+/*
+ * Copyright IBM Corp. 2022, 2022
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
-$hero-height: $spacing-13 * 3.475;
+@use '@carbon/react/scss/breakpoint' as breakpoint;
+@use '@carbon/react/scss/spacing' as spacing;
+@use '@carbon/react/scss/theme' as theme;
+@use '@carbon/react/scss/type' as type;
+
+$hero-height: spacing.$spacing-13 * 3.475;
 $illo-original-width: 1260px;
 $illo-original-height: 1078px;
 
 .container {
-  background: $background;
-  @include breakpoint(md) {
+  background: theme.$background;
+  @include breakpoint.breakpoint(md) {
     height: $hero-height;
 
     &::before {
@@ -20,11 +25,11 @@ $illo-original-height: 1078px;
       left: 0;
       width: 100vw;
       height: $hero-height;
-      background: $background;
+      background: theme.$background;
       content: '';
     }
   }
-  @include breakpoint-down(md) {
+  @include breakpoint.breakpoint-down(md) {
     position: relative;
   }
 }
@@ -36,24 +41,24 @@ $illo-original-height: 1078px;
 .column {
   position: relative;
   z-index: 1;
-  padding: $spacing-08 $spacing-05 ($spacing-08 + $spacing-12);
-  @include breakpoint(md) {
-    padding: ($spacing-09 + $spacing-03) 0 $spacing-05;
+  padding: spacing.$spacing-08 spacing.$spacing-05 (spacing.$spacing-08 + spacing.$spacing-12);
+  @include breakpoint.breakpoint(md) {
+    padding: (spacing.$spacing-09 + spacing.$spacing-03) 0 spacing.$spacing-05;
   }
-  @include breakpoint(lg) {
-    padding-right: $spacing-06;
+  @include breakpoint.breakpoint(lg) {
+    padding-right: spacing.$spacing-06;
   }
 }
 
 .title {
-  color: $text-primary;
-  @include type-style('display-01', true);
+  color: theme.$text-primary;
+  @include type.type-style('display-01', true);
 }
 
 .description {
-  margin-top: $spacing-06;
-  color: $text-primary;
-  @include type-style('body-long-02', true);
+  margin-top: spacing.$spacing-06;
+  color: theme.$text-primary;
+  @include type.type-style('body-long-02', true);
 }
 
 .image-wrap {
@@ -63,24 +68,24 @@ $illo-original-height: 1078px;
   overflow: hidden;
   width: 50%;
   height: $hero-height;
-  @include breakpoint(xlg) {
+  @include breakpoint.breakpoint(xlg) {
     // -18vw chosen to horizontally center the illo in white space at ultra max viewport
     right: -18vw;
     width: $hero-height * ($illo-original-width / $illo-original-height);
   }
-  @include breakpoint-down(md) {
+  @include breakpoint.breakpoint-down(md) {
     // -33% and 170% picked to get iphone viewport to match design spec size and position
     top: auto;
     right: -33%;
     bottom: 0;
     width: 170%;
-    height: $spacing-12;
+    height: spacing.$spacing-12;
   }
 }
 
 .image {
   object-position: center top;
-  @include breakpoint(md) {
+  @include breakpoint.breakpoint(md) {
     object-position: left center;
   }
 }

--- a/services/web-app/components/link/link.module.scss
+++ b/services/web-app/components/link/link.module.scss
@@ -1,9 +1,10 @@
-//
-// Copyright IBM Corp. 2022, 2022
-//
-// This source code is licensed under the Apache-2.0 license found in the
-// LICENSE file in the root directory of this source tree.
-//
+/*
+ * Copyright IBM Corp. 2022, 2022
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 .link {
   font-size: inherit;
 }

--- a/services/web-app/components/markdown/markdown.module.scss
+++ b/services/web-app/components/markdown/markdown.module.scss
@@ -1,31 +1,35 @@
-//
-// Copyright IBM Corp. 2022, 2022
-//
-// This source code is licensed under the Apache-2.0 license found in the
-// LICENSE file in the root directory of this source tree.
-//
+/*
+ * Copyright IBM Corp. 2022, 2022
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+@use '@carbon/react/scss/breakpoint' as breakpoint;
+@use '@carbon/react/scss/spacing' as spacing;
+@use '@carbon/react/scss/type' as type;
 
 /*  Spacing */
 .h1-container.h1-container {
-  --space: #{$spacing-12};
+  --space: #{spacing.$spacing-12};
 
   margin-top: var(--space);
 }
 
 .h2-container.h2-container {
-  --space: #{$spacing-11};
+  --space: #{spacing.$spacing-11};
 
   margin-top: var(--space);
 }
 
 .h3-container.h3-container {
-  --space: #{$spacing-10};
+  --space: #{spacing.$spacing-10};
 
   margin-top: var(--space);
 }
 
 .h4-container.h4-container {
-  --space: #{$spacing-07};
+  --space: #{spacing.$spacing-07};
 
   margin-top: var(--space);
 }
@@ -36,7 +40,7 @@
 }
 
 .paragraph-container {
-  --space: #{$spacing-06};
+  --space: #{spacing.$spacing-06};
 
   margin-top: var(--space);
 }
@@ -45,7 +49,7 @@
 .h2-container + *,
 .h3-container + *,
 .paragraph-container + * {
-  --space: #{$spacing-06};
+  --space: #{spacing.$spacing-06};
 }
 
 .h4-container + * {
@@ -54,7 +58,7 @@
 
 /* Spacing List */
 .list {
-  --space: #{$spacing-06};
+  --space: #{spacing.$spacing-06};
 
   margin-top: var(--space);
 }
@@ -65,68 +69,68 @@
 
 .ul {
   /* remove hanging bullet */
-  margin-left: $spacing-05;
+  margin-left: spacing.$spacing-05;
 }
 
 .ol {
   /*  remove hanging bullet */
-  margin-left: $spacing-06;
+  margin-left: spacing.$spacing-06;
 }
 
 /* TODO: pull in nested list prop diredtly from core Carbon issue #309 */
 .list-item .list {
-  margin-left: $spacing-07;
+  margin-left: spacing.$spacing-07;
 }
 
 /* Headings */
 .h1 {
-  @include type-style('expressive-heading-05', true);
+  @include type.type-style('expressive-heading-05', true);
 }
 
 .h2 {
-  @include type-style('expressive-heading-04', true);
+  @include type.type-style('expressive-heading-04', true);
 }
 
 .h3 {
-  @include type-style('expressive-heading-03', true);
+  @include type.type-style('expressive-heading-03', true);
 }
 
 .h4 {
-  @include type-style('heading-02');
+  @include type.type-style('heading-02');
 }
 
 .h5,
 .h6 {
-  @include type-style('heading-01');
+  @include type.type-style('heading-01');
 }
 
 /* Paragraph */
 .paragraph {
-  @include type-style('body-long-02');
+  @include type.type-style('body-long-02');
 }
 
 /*  Blockquote */
 .blockquote {
   padding-left: 1ch;
-  margin: $spacing-08 0;
-  margin-left: $spacing-05;
+  margin: spacing.$spacing-08 0;
+  margin-left: spacing.$spacing-05;
 
-  @include breakpoint('md') {
-    margin-left: $spacing-08;
+  @include breakpoint.breakpoint('md') {
+    margin-left: spacing.$spacing-08;
   }
 }
 
 .blockquote .paragraph {
-  @include type-style('expressive-heading-03', true);
+  @include type.type-style('expressive-heading-03', true);
 
   font-style: italic;
 }
 
 .blockquote cite {
-  @include type-style('body-long-01');
+  @include type.type-style('body-long-01');
 
   display: block;
-  margin-top: $spacing-02;
+  margin-top: spacing.$spacing-02;
   font-style: italic;
   text-indent: 0;
 }

--- a/services/web-app/components/page-breadcrumb/page-breadcrumb.module.scss
+++ b/services/web-app/components/page-breadcrumb/page-breadcrumb.module.scss
@@ -1,30 +1,37 @@
-//
-// Copyright IBM Corp. 2021, 2022
-//
-// This source code is licensed under the Apache-2.0 license found in the
-// LICENSE file in the root directory of this source tree.
-//
+/*
+ * Copyright IBM Corp. 2021, 2022
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+@use '@carbon/react/scss/breakpoint' as breakpoint;
+@use '@carbon/react/scss/spacing' as spacing;
+@use '@carbon/react/scss/theme' as theme;
+@use '@carbon/react/scss/type' as type;
+
+@use '~styles/mixins' as mixins;
 
 // 256px to match width of side nav
-$breadcrumb-container-width: $spacing-10 * 4;
+$breadcrumb-container-width: spacing.$spacing-10 * 4;
 
 .container {
   position: absolute;
   top: 0;
   left: 0;
   max-width: $breadcrumb-container-width;
-  padding: $spacing-06 0 0 $spacing-07;
+  padding: spacing.$spacing-06 0 0 spacing.$spacing-07;
 
-  @include breakpoint-down(md) {
+  @include breakpoint.breakpoint-down(md) {
     max-width: none;
-    padding-left: $spacing-05;
+    padding-left: spacing.$spacing-05;
   }
 }
 
 .text {
-  color: $text-primary;
-  @include type-style('body-long-01');
-  @include line-clamp(2);
+  color: theme.$text-primary;
+  @include type.type-style('body-long-01');
+  @include mixins.line-clamp(2);
 }
 
 .item {
@@ -38,23 +45,23 @@ $breadcrumb-container-width: $spacing-10 * 4;
     }
 
     .text {
-      padding-left: $spacing-05;
+      padding-left: spacing.$spacing-05;
     }
   }
 
   &:nth-child(3) {
-    margin-left: $spacing-05;
+    margin-left: spacing.$spacing-05;
   }
 
   &:nth-child(4) {
-    margin-left: $spacing-05 * 2;
+    margin-left: spacing.$spacing-05 * 2;
   }
 
   &:nth-child(5) {
-    margin-left: $spacing-05 * 3;
+    margin-left: spacing.$spacing-05 * 3;
   }
 
   &:nth-child(6) {
-    margin-left: $spacing-05 * 4;
+    margin-left: spacing.$spacing-05 * 4;
   }
 }

--- a/services/web-app/components/page-header/page-header.module.scss
+++ b/services/web-app/components/page-header/page-header.module.scss
@@ -55,7 +55,7 @@ $background-header: #d0e2ff;
   @include breakpoint.breakpoint-down(md) {
     @include type.type-style('quotation-02');
 
-    font-family: font-family('sans');
+    font-family: type.font-family('sans');
   }
 }
 

--- a/services/web-app/components/page-header/page-header.module.scss
+++ b/services/web-app/components/page-header/page-header.module.scss
@@ -1,18 +1,25 @@
-//
-// Copyright IBM Corp. 2021, 2022
-//
-// This source code is licensed under the Apache-2.0 license found in the
-// LICENSE file in the root directory of this source tree.
-//
+/*
+ * Copyright IBM Corp. 2021, 2022
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
-$page-header-height: $spacing-13 * 2;
+@use '@carbon/react/scss/breakpoint' as breakpoint;
+@use '@carbon/react/scss/spacing' as spacing;
+@use '@carbon/react/scss/theme' as theme;
+@use '@carbon/react/scss/type' as type;
+
+@use '~styles/mixins' as mixins;
+
+$page-header-height: spacing.$spacing-13 * 2;
 $background-header: #d0e2ff;
 
 .container {
   height: $page-header-height;
   background: $background-header;
-  @include breakpoint-down(md) {
-    padding: 0 $spacing-05;
+  @include breakpoint.breakpoint-down(md) {
+    padding: 0 spacing.$spacing-05;
   }
 
   &::before {
@@ -34,24 +41,24 @@ $background-header: #d0e2ff;
 
   &-last {
     justify-content: flex-end;
-    @include breakpoint-down(md) {
+    @include breakpoint.breakpoint-down(md) {
       display: none;
     }
   }
 }
 
 .title {
-  margin-bottom: $spacing-07;
-  color: $text-primary;
-  @include type-style('display-01', true);
-  @include line-clamp(2);
-  @include breakpoint-down(md) {
-    @include type-style('quotation-02');
+  margin-bottom: spacing.$spacing-07;
+  color: theme.$text-primary;
+  @include type.type-style('display-01', true);
+  @include mixins.line-clamp(2);
+  @include breakpoint.breakpoint-down(md) {
+    @include type.type-style('quotation-02');
 
     font-family: font-family('sans');
   }
 }
 
 .pictogram {
-  margin-bottom: $spacing-08;
+  margin-bottom: spacing.$spacing-08;
 }

--- a/services/web-app/components/page-not-found/page-not-found.module.scss
+++ b/services/web-app/components/page-not-found/page-not-found.module.scss
@@ -5,15 +5,19 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+@use '@carbon/react/scss/breakpoint' as breakpoint;
+@use '@carbon/react/scss/spacing' as spacing;
+@use '@carbon/react/scss/type' as type;
+
 .title {
-  @include type-style('display-01', true);
+  @include type.type-style('display-01', true);
 }
 
 .grid {
-  margin-top: $spacing-10;
-  @include breakpoint-down(md) {
-    padding-right: $spacing-05;
-    padding-left: $spacing-05;
+  margin-top: spacing.$spacing-10;
+  @include breakpoint.breakpoint-down(md) {
+    padding-right: spacing.$spacing-05;
+    padding-left: spacing.$spacing-05;
   }
 }
 
@@ -21,6 +25,6 @@
 .button {
   width: 100%;
   max-width: none;
-  padding-right: $spacing-05;
-  margin-top: $spacing-07;
+  padding-right: spacing.$spacing-05;
+  margin-top: spacing.$spacing-07;
 }

--- a/services/web-app/components/status-icon/status-icon.module.scss
+++ b/services/web-app/components/status-icon/status-icon.module.scss
@@ -1,17 +1,19 @@
-//
-// Copyright IBM Corp. 2021, 2022
-//
-// This source code is licensed under the Apache-2.0 license found in the
-// LICENSE file in the root directory of this source tree.
-//
+/*
+ * Copyright IBM Corp. 2021, 2022
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+@use '@carbon/react/scss/theme' as theme;
 
 $status-experimental: #8a3ffc;
 
 .icon {
-  color: $icon-primary;
+  color: theme.$icon-primary;
 
   &--draft {
-    color: $text-helper;
+    color: theme.$text-helper;
   }
 
   &--experimental {
@@ -19,10 +21,10 @@ $status-experimental: #8a3ffc;
   }
 
   &--stable {
-    color: $support-success;
+    color: theme.$support-success;
   }
 
   &--deprecated {
-    color: $support-error;
+    color: theme.$support-error;
   }
 }

--- a/services/web-app/layouts/layout/layout.module.scss
+++ b/services/web-app/layouts/layout/layout.module.scss
@@ -1,14 +1,21 @@
-//
-// Copyright IBM Corp. 2021, 2022
-//
-// This source code is licensed under the Apache-2.0 license found in the
-// LICENSE file in the root directory of this source tree.
-//
+/*
+ * Copyright IBM Corp. 2021, 2022
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+@use '@carbon/react/scss/breakpoint' as breakpoint;
+@use '@carbon/react/scss/spacing' as spacing;
+@use '@carbon/react/scss/theme' as theme;
+@use '@carbon/react/scss/type' as type;
+@use '@carbon/styles/scss/utilities/z-index' as z-index;
+
 .body {
   // overflow hidden for full-bleed backgrounds
   overflow: hidden;
   flex-grow: 1;
-  background: $background;
+  background: theme.$background;
 }
 
 .header {
@@ -21,29 +28,29 @@
 .main {
   // position for PageBreadcrumb
   position: relative;
-  margin: $spacing-09 0 0;
+  margin: spacing.$spacing-09 0 0;
   // have carbon overlay use higher z-index than we're using on our custom components
   :global(.cds--side-nav__overlay.cds--side-nav__overlay-active) {
-    z-index: layout.z('overlay');
+    z-index: z-index.z('overlay');
   }
 }
 
 .side-nav-heading {
-  padding-bottom: $spacing-03;
-  border-bottom: 1px solid $layer-accent;
-  margin: $spacing-08 $spacing-05 $spacing-03;
-  @include type-style('label-01');
+  padding-bottom: spacing.$spacing-03;
+  border-bottom: 1px solid theme.$layer-accent;
+  margin: spacing.$spacing-08 spacing.$spacing-05 spacing.$spacing-03;
+  @include type.type-style('label-01');
 }
 
 .header-name {
   height: 100%;
-  @include breakpoint(lg) {
+  @include breakpoint.breakpoint(lg) {
     position: absolute;
   }
 }
 
 .header-grid {
-  @include breakpoint(lg) {
+  @include breakpoint.breakpoint(lg) {
     width: 100%;
     height: 100%;
     margin: 0;
@@ -51,5 +58,5 @@
 }
 
 .header-navigation {
-  margin-left: -$spacing-05;
+  margin-left: -(spacing.$spacing-05);
 }

--- a/services/web-app/next.config.js
+++ b/services/web-app/next.config.js
@@ -29,20 +29,6 @@ module.exports = withMDX({
   images: {
     domains: ['raw.githubusercontent.com']
   },
-  sassOptions: {
-    includePaths: [path.join(__dirname, 'styles')],
-    prependData: `
-      @use '~@carbon/motion/scss/motion' as *;
-      @use '~@carbon/react/scss/breakpoint' as *;
-      @use '~@carbon/react/scss/spacing' as *;
-      @use '~@carbon/react/scss/theme' as *;
-      @use '~@carbon/react/scss/themes';
-      @use '~@carbon/react/scss/type' as *;
-      @use '~@carbon/react/scss/zone';
-      @use './styles/mixins' as *;
-      @use '~carbon-components/scss/globals/scss/_layout' as layout;
-    `
-  },
   swcMinify: true,
   webpack(config) {
     const rules = config.module.rules

--- a/services/web-app/pages/assets/[host]/[org]/[repo]/[library]/[ref]/[asset].module.scss
+++ b/services/web-app/pages/assets/[host]/[org]/[repo]/[library]/[ref]/[asset].module.scss
@@ -1,17 +1,21 @@
-//
-// Copyright IBM Corp. 2022, 2022
-//
-// This source code is licensed under the Apache-2.0 license found in the
-// LICENSE file in the root directory of this source tree.
-//
+/*
+ * Copyright IBM Corp. 2022, 2022
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+@use '@carbon/react/scss/breakpoint' as breakpoint;
+@use '@carbon/react/scss/spacing' as spacing;
+
 .dashboard {
-  margin-top: $spacing-07;
-  margin-bottom: $spacing-07;
+  margin-top: spacing.$spacing-07;
+  margin-bottom: spacing.$spacing-07;
 }
 
 .sponsor-icon {
-  @include breakpoint-down(md) {
-    right: $spacing-04;
+  @include breakpoint.breakpoint-down(md) {
+    right: spacing.$spacing-04;
     left: auto;
   }
 }
@@ -19,7 +23,7 @@
 .status-icon {
   position: relative;
   top: 2px;
-  margin-right: $spacing-02;
+  margin-right: spacing.$spacing-02;
   margin-left: -1px;
 }
 
@@ -30,8 +34,8 @@
   bottom: 0;
   width: 100%;
   max-width: none;
-  padding-right: $spacing-05;
-  @include breakpoint(lg) {
+  padding-right: spacing.$spacing-05;
+  @include breakpoint.breakpoint(lg) {
     width: 50%;
   }
 }

--- a/services/web-app/pages/assets/[host]/[org]/[repo]/[library]/[ref]/index.module.scss
+++ b/services/web-app/pages/assets/[host]/[org]/[repo]/[library]/[ref]/index.module.scss
@@ -1,17 +1,21 @@
-//
-// Copyright IBM Corp. 2022, 2022
-//
-// This source code is licensed under the Apache-2.0 license found in the
-// LICENSE file in the root directory of this source tree.
-//
+/*
+ * Copyright IBM Corp. 2021, 2022
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+@use '@carbon/react/scss/breakpoint' as breakpoint;
+@use '@carbon/react/scss/spacing' as spacing;
+
 .dashboard {
-  margin-top: $spacing-07;
-  margin-bottom: $spacing-07;
+  margin-top: spacing.$spacing-07;
+  margin-bottom: spacing.$spacing-07;
 }
 
 .sponsor-icon {
-  @include breakpoint-down(md) {
-    right: $spacing-04;
+  @include breakpoint.breakpoint-down(md) {
+    right: spacing.$spacing-04;
     left: auto;
   }
 }
@@ -23,8 +27,8 @@
   bottom: 0;
   width: 100%;
   max-width: none;
-  padding-right: $spacing-05;
-  @include breakpoint(lg) {
+  padding-right: spacing.$spacing-05;
+  @include breakpoint.breakpoint(lg) {
     width: 50%;
   }
 }

--- a/services/web-app/pages/assets/index/index.module.scss
+++ b/services/web-app/pages/assets/index/index.module.scss
@@ -1,11 +1,17 @@
-//
-// Copyright IBM Corp. 2022, 2022
-//
-// This source code is licensed under the Apache-2.0 license found in the
-// LICENSE file in the root directory of this source tree.
-//
+/*
+ * Copyright IBM Corp. 2022, 2022
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+@use '@carbon/react/scss/breakpoint' as breakpoint;
+@use '@carbon/react/scss/spacing' as spacing;
+@use '@carbon/react/scss/theme' as theme;
+@use '@carbon/react/scss/type' as type;
+
 .container {
-  padding-bottom: $spacing-13 + $spacing-07;
+  padding-bottom: spacing.$spacing-13 + spacing.$spacing-07;
 }
 
 /**
@@ -21,11 +27,11 @@
     right: 0;
     left: 0;
     height: 1px;
-    background-color: $border-strong-01;
+    background-color: theme.$border-strong-01;
     content: '';
-    @include breakpoint(md) {
-      margin-right: -$spacing-05;
-      margin-left: -$spacing-05;
+    @include breakpoint.breakpoint(md) {
+      margin-right: -(spacing.$spacing-05);
+      margin-left: -(spacing.$spacing-05);
     }
   }
 }
@@ -45,17 +51,17 @@
  */
 
 .subheading {
-  padding: $spacing-10 $spacing-05;
-  @include type-style('expressive-heading-04');
-  @include breakpoint(md) {
-    padding-right: $spacing-06;
+  padding: spacing.$spacing-10 spacing.$spacing-05;
+  @include type.type-style('expressive-heading-04');
+  @include breakpoint.breakpoint(md) {
+    padding-right: spacing.$spacing-06;
     padding-left: 0;
   }
-  @include breakpoint(lg) {
-    padding-right: $spacing-05;
+  @include breakpoint.breakpoint(lg) {
+    padding-right: spacing.$spacing-05;
   }
-  @include breakpoint(xlg) {
-    padding-right: $spacing-06;
+  @include breakpoint.breakpoint(xlg) {
+    padding-right: spacing.$spacing-06;
   }
 }
 
@@ -65,8 +71,8 @@
 
 .highlights {
   position: relative;
-  padding: 0 $spacing-05;
-  @include breakpoint(md) {
+  padding: 0 spacing.$spacing-05;
+  @include breakpoint.breakpoint(md) {
     padding: 0;
   }
 
@@ -76,7 +82,7 @@
     left: -100vw;
     width: 200vw;
     height: 100%;
-    background: $layer-01;
+    background: theme.$layer-01;
     content: '';
   }
 }
@@ -85,55 +91,55 @@
   position: relative;
 
   &--height {
-    @include breakpoint(md) {
-      min-height: $spacing-13 + $spacing-09;
+    @include breakpoint.breakpoint(md) {
+      min-height: spacing.$spacing-13 + spacing.$spacing-09;
     }
-    @include breakpoint(lg) {
-      min-height: $spacing-13 + $spacing-06;
+    @include breakpoint.breakpoint(lg) {
+      min-height: spacing.$spacing-13 + spacing.$spacing-06;
     }
   }
 }
 
 .highlight-heading {
-  margin-top: $spacing-08;
-  @include type-style('expressive-heading-03');
-  @include breakpoint(md) {
-    margin-top: $spacing-08 + $spacing-02;
+  margin-top: spacing.$spacing-08;
+  @include type.type-style('expressive-heading-03');
+  @include breakpoint.breakpoint(md) {
+    margin-top: spacing.$spacing-08 + spacing.$spacing-02;
   }
-  @include breakpoint(lg) {
-    padding-right: $spacing-07;
+  @include breakpoint.breakpoint(lg) {
+    padding-right: spacing.$spacing-07;
   }
 
   &--big {
-    margin-top: $spacing-07;
-    @include type-style('expressive-heading-04');
+    margin-top: spacing.$spacing-07;
+    @include type.type-style('expressive-heading-04');
   }
 }
 
 .highlight-description {
-  margin: $spacing-06 0 ($spacing-08 + $spacing-06);
-  @include type-style('body-long-02');
-  @include breakpoint(md) {
-    margin: $spacing-07 0;
+  margin: spacing.$spacing-06 0 (spacing.$spacing-08 + spacing.$spacing-06);
+  @include type.type-style('body-long-02');
+  @include breakpoint.breakpoint(md) {
+    margin: spacing.$spacing-07 0;
   }
-  @include breakpoint(lg) {
-    padding-right: $spacing-05;
+  @include breakpoint.breakpoint(lg) {
+    padding-right: spacing.$spacing-05;
   }
-  @include breakpoint(xlg) {
+  @include breakpoint.breakpoint(xlg) {
     padding-right: 0;
   }
 
   &--big {
-    @include type-style('expressive-heading-04');
-    @include breakpoint(md) {
-      margin: $spacing-08 0;
+    @include type.type-style('expressive-heading-04');
+    @include breakpoint.breakpoint(md) {
+      margin: spacing.$spacing-08 0;
     }
   }
 }
 
 .highlight-title {
   display: block;
-  @include type-style('expressive-heading-02');
+  @include type.type-style('expressive-heading-02');
 }
 
 /**
@@ -141,31 +147,31 @@
  */
 
 .content-column {
-  padding-right: $spacing-05;
-  padding-left: $spacing-05;
-  @include breakpoint(md) {
-    padding-right: $spacing-06;
+  padding-right: spacing.$spacing-05;
+  padding-left: spacing.$spacing-05;
+  @include breakpoint.breakpoint(md) {
+    padding-right: spacing.$spacing-06;
     padding-left: 0;
   }
-  @include breakpoint(lg) {
-    padding-right: $spacing-05;
+  @include breakpoint.breakpoint(lg) {
+    padding-right: spacing.$spacing-05;
   }
-  @include breakpoint(xlg) {
-    padding-right: $spacing-06;
+  @include breakpoint.breakpoint(xlg) {
+    padding-right: spacing.$spacing-06;
   }
 }
 
 .content-heading {
-  margin-top: $spacing-11;
-  @include type-style('expressive-heading-04');
+  margin-top: spacing.$spacing-11;
+  @include type.type-style('expressive-heading-04');
 }
 
 .content-copy {
-  margin-top: $spacing-06;
-  @include type-style('body-long-02');
+  margin-top: spacing.$spacing-06;
+  @include type.type-style('body-long-02');
 
   &:last-child {
-    margin-bottom: $spacing-10;
+    margin-bottom: spacing.$spacing-10;
   }
 }
 
@@ -174,52 +180,52 @@
  */
 
 .release {
-  padding: 0 $spacing-05 ($spacing-09 + $spacing-03);
-  @include breakpoint(md) {
+  padding: 0 spacing.$spacing-05 (spacing.$spacing-09 + spacing.$spacing-03);
+  @include breakpoint.breakpoint(md) {
     padding-right: 0;
     padding-left: 0;
   }
 }
 
 .release-heading {
-  margin-top: $spacing-07;
-  @include type-style('expressive-heading-04');
+  margin-top: spacing.$spacing-07;
+  @include type.type-style('expressive-heading-04');
 }
 
 .release-subheading {
-  @include type-style('expressive-heading-02');
+  @include type.type-style('expressive-heading-02');
 }
 
 .release-copy {
-  @include type-style('body-long-02');
+  @include type.type-style('body-long-02');
 
   & + & {
-    margin-top: $spacing-06;
+    margin-top: spacing.$spacing-06;
   }
 }
 
 .release-content {
-  margin-top: $spacing-06;
-  @include breakpoint(md) {
-    padding-right: $spacing-06;
+  margin-top: spacing.$spacing-06;
+  @include breakpoint.breakpoint(md) {
+    padding-right: spacing.$spacing-06;
   }
-  @include breakpoint(lg) {
-    padding-right: $spacing-05;
-    margin-top: $spacing-07;
+  @include breakpoint.breakpoint(lg) {
+    padding-right: spacing.$spacing-05;
+    margin-top: spacing.$spacing-07;
   }
-  @include breakpoint(xlg) {
-    padding-right: $spacing-06;
+  @include breakpoint.breakpoint(xlg) {
+    padding-right: spacing.$spacing-06;
   }
 }
 
 .release-image {
-  margin-top: $spacing-06;
-  @include breakpoint-down(md) {
+  margin-top: spacing.$spacing-06;
+  @include breakpoint.breakpoint-down(md) {
     display: none;
   }
 }
 
 .release-image-caption {
-  margin-top: $spacing-05;
-  @include type-style('label-01');
+  margin-top: spacing.$spacing-05;
+  @include type.type-style('label-01');
 }

--- a/services/web-app/pages/assets/libraries.module.scss
+++ b/services/web-app/pages/assets/libraries.module.scss
@@ -1,109 +1,119 @@
-//
-// Copyright IBM Corp. 2022, 2022
-//
-// This source code is licensed under the Apache-2.0 license found in the
-// LICENSE file in the root directory of this source tree.
-//
+/*
+ * Copyright IBM Corp. 2021, 2022
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+@use '@carbon/react/scss/breakpoint' as breakpoint;
+@use '@carbon/react/scss/motion' as motion;
+@use '@carbon/motion/scss' as motion-utils;
+@use '@carbon/react/scss/spacing' as spacing;
+@use '@carbon/react/scss/theme' as theme;
+@use '@carbon/react/scss/type' as type;
+
+@use '~styles/mixins' as mixins;
+
 .list {
-  border-bottom: 1px solid $layer-accent;
-  margin: $spacing-07 0;
-  @include breakpoint(md) {
-    margin-right: -$spacing-05;
-    margin-left: -$spacing-05;
+  border-bottom: 1px solid theme.$layer-accent;
+  margin: spacing.$spacing-07 0;
+  @include breakpoint.breakpoint(md) {
+    margin-right: -(spacing.$spacing-05);
+    margin-left: -(spacing.$spacing-05);
   }
 }
 
 .anchor {
   position: relative;
   display: block;
-  border-top: 1px solid $layer-accent;
-  background: $layer-01;
+  border-top: 1px solid theme.$layer-accent;
+  background: theme.$layer-01;
   text-decoration: none;
-  transition: background $fast-02 carbon--motion(standard, productive);
+  transition: background motion.$duration-fast-02 motion-utils.carbon--motion(standard, productive);
 
   &:hover,
   &:focus {
-    background: $layer-hover;
+    background: theme.$layer-hover;
   }
 
   &:active {
-    outline: 2px solid $focus;
+    outline: 2px solid theme.$focus;
     outline-offset: -2px;
   }
 }
 
 .content {
-  padding: $spacing-05;
-  @include breakpoint(md) {
-    height: $spacing-13 + $spacing-05;
+  padding: spacing.$spacing-05;
+  @include breakpoint.breakpoint(md) {
+    height: spacing.$spacing-13 + spacing.$spacing-05;
   }
-  @include breakpoint(xlg) {
-    padding-right: $spacing-05 + $spacing-06;
+  @include breakpoint.breakpoint(xlg) {
+    padding-right: spacing.$spacing-05 + spacing.$spacing-06;
   }
 }
 
 .sponsor {
-  color: $text-primary;
-  @include line-clamp(1);
-  @include type-style('label-01');
+  color: theme.$text-primary;
+  @include mixins.line-clamp(1);
+  @include type.type-style('label-01');
 }
 
 .name {
-  color: $text-primary;
-  @include line-clamp(2);
-  @include type-style('productive-heading-02');
+  color: theme.$text-primary;
+  @include mixins.line-clamp(2);
+  @include type.type-style('productive-heading-02');
 }
 
 .description {
-  margin-top: $spacing-02;
-  color: $text-primary;
-  @include line-clamp(3);
-  @include type-style('body-short-01');
+  margin-top: spacing.$spacing-02;
+  color: theme.$text-primary;
+  @include mixins.line-clamp(3);
+  @include type.type-style('body-short-01');
 }
 
 .meta {
   position: absolute;
-  bottom: $spacing-04;
-  left: $spacing-04;
-  color: $text-secondary;
-  @include type-style('label-01');
+  bottom: spacing.$spacing-04;
+  left: spacing.$spacing-04;
+  color: theme.$text-secondary;
+  @include type.type-style('label-01');
 }
 
 .meta-item {
   display: inline;
 
   &:not(:first-child) {
-    margin-left: $spacing-03;
+    margin-left: spacing.$spacing-03;
   }
 }
 
 .meta-icon {
   position: relative;
   top: 3px;
-  margin-right: $spacing-02;
+  margin-right: spacing.$spacing-02;
 }
 
 .icon {
   position: absolute;
-  right: $spacing-04;
-  bottom: $spacing-04;
+  right: spacing.$spacing-04;
+  bottom: spacing.$spacing-04;
   display: block;
-  width: $spacing-09;
-  height: $spacing-09;
-  border: 1px solid $border-subtle;
-  background: $layer-01;
+  width: spacing.$spacing-09;
+  height: spacing.$spacing-09;
+  border: 1px solid theme.$border-subtle;
+  background: theme.$layer-01;
   border-radius: 100%;
-  color: $icon-primary;
-  transition: all $fast-02 carbon--motion(standard, productive);
-  @include breakpoint(xlg) {
-    width: $spacing-09 + $spacing-03;
-    height: $spacing-09 + $spacing-03;
+  color: theme.$icon-primary;
+  transition: all motion.$duration-fast-02 motion-utils.carbon--motion(standard, productive);
+  @include breakpoint.breakpoint(xlg) {
+    width: spacing.$spacing-09 + spacing.$spacing-03;
+    height: spacing.$spacing-09 + spacing.$spacing-03;
   }
 
   .anchor:hover &,
   .anchor:focus & {
-    border-color: $border-subtle-selected;
-    background: $layer-hover;
+    border-color: theme.$border-subtle-selected;
+    background: theme.$layer-hover;
   }
 }
 
@@ -112,5 +122,5 @@
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  transition: opacity $fast-02 carbon--motion(standard, productive);
+  transition: opacity motion.$duration-fast-02 motion-utils.carbon--motion(standard, productive);
 }

--- a/services/web-app/pages/assets/libraries.module.scss
+++ b/services/web-app/pages/assets/libraries.module.scss
@@ -7,7 +7,6 @@
 
 @use '@carbon/react/scss/breakpoint' as breakpoint;
 @use '@carbon/react/scss/motion' as motion;
-@use '@carbon/motion/scss' as motion-utils;
 @use '@carbon/react/scss/spacing' as spacing;
 @use '@carbon/react/scss/theme' as theme;
 @use '@carbon/react/scss/type' as type;
@@ -29,7 +28,7 @@
   border-top: 1px solid theme.$layer-accent;
   background: theme.$layer-01;
   text-decoration: none;
-  transition: background motion.$duration-fast-02 motion-utils.carbon--motion(standard, productive);
+  transition: background motion.$duration-fast-02 motion.motion(standard, productive);
 
   &:hover,
   &:focus {
@@ -104,7 +103,7 @@
   background: theme.$layer-01;
   border-radius: 100%;
   color: theme.$icon-primary;
-  transition: all motion.$duration-fast-02 motion-utils.carbon--motion(standard, productive);
+  transition: all motion.$duration-fast-02 motion.motion(standard, productive);
   @include breakpoint.breakpoint(xlg) {
     width: spacing.$spacing-09 + spacing.$spacing-03;
     height: spacing.$spacing-09 + spacing.$spacing-03;
@@ -122,5 +121,5 @@
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  transition: opacity motion.$duration-fast-02 motion-utils.carbon--motion(standard, productive);
+  transition: opacity motion.$duration-fast-02 motion.motion(standard, productive);
 }

--- a/services/web-app/pages/pages.module.scss
+++ b/services/web-app/pages/pages.module.scss
@@ -1,21 +1,26 @@
-//
-// Copyright IBM Corp. 2021, 2022
-//
-// This source code is licensed under the Apache-2.0 license found in the
-// LICENSE file in the root directory of this source tree.
-//
+/*
+ * Copyright IBM Corp. 2021, 2022
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+@use '@carbon/react/scss/breakpoint' as breakpoint;
+@use '@carbon/react/scss/spacing' as spacing;
+@use '@carbon/react/scss/type' as type;
+
 .content {
-  margin: $spacing-07 0;
-  @include breakpoint-down(md) {
-    padding: 0 $spacing-05;
+  margin: spacing.$spacing-07 0;
+  @include breakpoint.breakpoint-down(md) {
+    padding: 0 spacing.$spacing-05;
   }
 }
 
 .data {
-  margin: $spacing-07 0;
+  margin: spacing.$spacing-07 0;
   white-space: pre-wrap;
   word-break: break-all;
-  @include type-style('code-01');
+  @include type.type-style('code-01');
 }
 
 .bullets {
@@ -23,5 +28,5 @@
 }
 
 .bullets-item {
-  margin-left: $spacing-07;
+  margin-left: spacing.$spacing-07;
 }

--- a/services/web-app/styles/_base.scss
+++ b/services/web-app/styles/_base.scss
@@ -1,9 +1,10 @@
-//
-// Copyright IBM Corp. 2021, 2022
-//
-// This source code is licensed under the Apache-2.0 license found in the
-// LICENSE file in the root directory of this source tree.
-//
+/*
+ * Copyright IBM Corp. 2021, 2022
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 *,
 *::before,
 *::after {

--- a/services/web-app/styles/_mixins.scss
+++ b/services/web-app/styles/_mixins.scss
@@ -1,9 +1,9 @@
-//
-// Copyright IBM Corp. 2021, 2022
-//
-// This source code is licensed under the Apache-2.0 license found in the
-// LICENSE file in the root directory of this source tree.
-//
+/*
+ * Copyright IBM Corp. 2021, 2022
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 @mixin line-clamp($lines: 2) {
   display: -webkit-box;

--- a/services/web-app/styles/styles.scss
+++ b/services/web-app/styles/styles.scss
@@ -1,9 +1,9 @@
-//
-// Copyright IBM Corp. 2021, 2022
-//
-// This source code is licensed under the Apache-2.0 license found in the
-// LICENSE file in the root directory of this source tree.
-//
+/*
+ * Copyright IBM Corp. 2021, 2022
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 @use './vendor';
 @use './base';

--- a/services/web-app/styles/vendor/_carbon.scss
+++ b/services/web-app/styles/vendor/_carbon.scss
@@ -5,4 +5,4 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-@use '@carbon/styles';
+@use '@carbon/react';

--- a/services/web-app/styles/vendor/_carbon.scss
+++ b/services/web-app/styles/vendor/_carbon.scss
@@ -1,8 +1,8 @@
-//
-// Copyright IBM Corp. 2021, 2022
-//
-// This source code is licensed under the Apache-2.0 license found in the
-// LICENSE file in the root directory of this source tree.
-//
+/*
+ * Copyright IBM Corp. 2021, 2022
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 @use '@carbon/styles';

--- a/services/web-app/styles/vendor/_overrides.scss
+++ b/services/web-app/styles/vendor/_overrides.scss
@@ -1,9 +1,10 @@
-//
-// Copyright IBM Corp. 2021, 2022
-//
-// This source code is licensed under the Apache-2.0 license found in the
-// LICENSE file in the root directory of this source tree.
-//
+/*
+ * Copyright IBM Corp. 2021, 2022
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 .cds--content {
   margin-top: 3rem;
 }

--- a/services/web-app/styles/vendor/index.scss
+++ b/services/web-app/styles/vendor/index.scss
@@ -1,9 +1,9 @@
-//
-// Copyright IBM Corp. 2021, 2022
-//
-// This source code is licensed under the Apache-2.0 license found in the
-// LICENSE file in the root directory of this source tree.
-//
+/*
+ * Copyright IBM Corp. 2021, 2022
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 @use './carbon';
 @use './overrides';


### PR DESCRIPTION
Fixes #391

This fixes the build failures we've been seeing because of duplicate sass imports (`@use`s) causing re-configuration of modules after they've already been configured and other circular-type dependency issues. It foregoes the convenience of globally available variables/tokens/etc. in favor of explicit imports and namespaced modules (this is actually the sass recommended approach).

In my local testing, I have seen a 100% success rate of dev, production, and docker-based builds.

## Help Wanted!

### Docker Build

If anyone is able to run the following command locally to ensure that it builds successfully, that would be a huge help for variation and confidence in the refactor:

(Note: you'll need to have [Docker Desktop](https://www.docker.com/products/docker-desktop) installed in order to run the build locally.

```
CARBON_RUN_MODE=PROD CARBON_GITHUB_TOKEN=[your public github token] node packages/micromanage docker --build  @carbon-platform/web-app
```

### Visual Regression

This change also could use a visual regression test to make sure all of the styles are still behaving as expected.