### PR TITLE
fix(web-app): catalog sticky controls

### DIFF
--- a/services/web-app/components/catalog-multislect-filter/catalog-multiselect-filter.module.scss
+++ b/services/web-app/components/catalog-multislect-filter/catalog-multiselect-filter.module.scss
@@ -83,7 +83,7 @@
 }
 
 .content {
-  width: 100vw;
+  width: calc(100vw - var(--scrollbar-width));
   max-width: none;
   @include breakpoint(md) {
     // span two columns, where each column has a 1px gutter

--- a/services/web-app/components/hero/hero.js
+++ b/services/web-app/components/hero/hero.js
@@ -20,14 +20,16 @@ const Hero = ({ title, description, image, imageAlt }) => {
         </Column>
       </Grid>
       {image && (
-        <div className={styles.imageWrap}>
-          <Image
-            alt={imageAlt}
-            className={styles.image}
-            src={image}
-            layout="fill"
-            objectFit="cover"
-          />
+        <div className={styles.imageContainer}>
+          <div className={styles.imagePosition}>
+            <Image
+              alt={imageAlt}
+              className={styles.image}
+              src={image}
+              layout="fill"
+              objectFit="cover"
+            />
+          </div>
         </div>
       )}
     </Theme>

--- a/services/web-app/components/hero/hero.module.scss
+++ b/services/web-app/components/hero/hero.module.scss
@@ -6,6 +6,7 @@
 //
 
 $hero-height: $spacing-13 * 3.475;
+$illo-mobile-height: $spacing-08 + $spacing-12;
 $illo-original-width: 1260px;
 $illo-original-height: 1078px;
 
@@ -36,7 +37,7 @@ $illo-original-height: 1078px;
 .column {
   position: relative;
   z-index: 1;
-  padding: $spacing-08 $spacing-05 ($spacing-08 + $spacing-12);
+  padding: $spacing-08 $spacing-05 $illo-mobile-height;
   @include breakpoint(md) {
     padding: ($spacing-09 + $spacing-03) 0 $spacing-05;
   }
@@ -56,17 +57,35 @@ $illo-original-height: 1078px;
   @include type-style('body-long-02', true);
 }
 
-.image-wrap {
+.image-container {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  overflow: hidden;
+  width: 100vw;
+  height: $illo-mobile-height;
+
+  @include breakpoint(md) {
+    top: 0;
+    bottom: auto;
+    height: $hero-height;
+  }
+}
+
+.image-position {
   position: absolute;
   top: 0;
   right: -25vw;
-  overflow: hidden;
   width: 50%;
   height: $hero-height;
   @include breakpoint(xlg) {
     // -18vw chosen to horizontally center the illo in white space at ultra max viewport
     right: -18vw;
     width: $hero-height * ($illo-original-width / $illo-original-height);
+  }
+  @include breakpoint(max) {
+    // match xlg position
+    right: -285px;
   }
   @include breakpoint-down(md) {
     // -33% and 170% picked to get iphone viewport to match design spec size and position

--- a/services/web-app/components/hero/hero.module.scss
+++ b/services/web-app/components/hero/hero.module.scss
@@ -43,7 +43,7 @@ $illo-original-height: 1078px;
   position: relative;
   z-index: 1;
   padding: spacing.$spacing-08 spacing.$spacing-05 $illo-mobile-height;
-  @include breakpoint(md) {
+  @include breakpoint.breakpoint(md) {
     padding: (spacing.$spacing-09 + spacing.$spacing-03) 0 spacing.$spacing-05;
   }
   @include breakpoint.breakpoint(lg) {
@@ -70,7 +70,7 @@ $illo-original-height: 1078px;
   width: calc(100vw - var(--scrollbar-width));
   height: $illo-mobile-height;
 
-  @include breakpoint(md) {
+  @include breakpoint.breakpoint(md) {
     top: 0;
     bottom: auto;
     height: $hero-height;
@@ -88,11 +88,11 @@ $illo-original-height: 1078px;
     right: -18vw;
     width: $hero-height * ($illo-original-width / $illo-original-height);
   }
-  @include breakpoint(max) {
+  @include breakpoint.breakpoint(max) {
     // match xlg position
     right: -285px;
   }
-  @include breakpoint-down(md) {
+  @include breakpoint.breakpoint-down(md) {
     // -33% and 170% picked to get iphone viewport to match design spec size and position
     top: auto;
     right: -33%;

--- a/services/web-app/components/hero/hero.module.scss
+++ b/services/web-app/components/hero/hero.module.scss
@@ -19,7 +19,7 @@ $illo-original-height: 1078px;
       position: absolute;
       z-index: 0;
       left: 0;
-      width: 100vw;
+      width: calc(100vw - var(--scrollbar-width));
       height: $hero-height;
       background: $background;
       content: '';
@@ -62,7 +62,7 @@ $illo-original-height: 1078px;
   bottom: 0;
   left: 0;
   overflow: hidden;
-  width: 100vw;
+  width: calc(100vw - var(--scrollbar-width));
   height: $illo-mobile-height;
 
   @include breakpoint(md) {

--- a/services/web-app/components/page-header/page-header.module.scss
+++ b/services/web-app/components/page-header/page-header.module.scss
@@ -19,7 +19,7 @@ $background-header: #d0e2ff;
     position: absolute;
     z-index: 0;
     left: 0;
-    width: 100vw;
+    width: calc(100vw - var(--scrollbar-width));
     height: $page-header-height;
     background: $background-header;
     content: '';

--- a/services/web-app/layouts/layout/layout.js
+++ b/services/web-app/layouts/layout/layout.js
@@ -42,6 +42,17 @@ const Layout = ({ children }) => {
   const [showSideNav, setShowSideNav] = useState(true)
   const { navData } = useContext(LayoutContext)
 
+  // For use with 100vw widths to account for the scrollbar width, e.g. instead of `width: 100vw;`
+  // use `width: calc(100vw - var(--scrollbar-width));`.
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      document.documentElement.style.setProperty(
+        '--scrollbar-width',
+        window.innerWidth - document.documentElement.clientWidth + 'px'
+      )
+    }
+  }, [])
+
   useEffect(() => {
     setShowSideNav(!router.pathname.startsWith('/assets/[host]/[org]/[repo]/[library]/[ref]'))
   }, [router.pathname])

--- a/services/web-app/layouts/layout/layout.module.scss
+++ b/services/web-app/layouts/layout/layout.module.scss
@@ -5,8 +5,6 @@
 // LICENSE file in the root directory of this source tree.
 //
 .body {
-  // overflow hidden for full-bleed backgrounds
-  overflow: hidden;
   flex-grow: 1;
   background: $background;
 }

--- a/services/web-app/pages/assets/index/index.module.scss
+++ b/services/web-app/pages/assets/index/index.module.scss
@@ -73,11 +73,23 @@
   &::before {
     position: absolute;
     top: 0;
-    left: -100vw;
-    width: 200vw;
+    left: 0;
+    width: 100vw;
     height: 100%;
     background: $layer-01;
     content: '';
+    @include breakpoint(md) {
+      // grid margin + gutter
+      left: -($spacing-05 + $spacing-05);
+    }
+    @include breakpoint(lg) {
+      // grid margin + 6.25% column * 4 colums + gutter
+      left: calc(-25vw - #{$spacing-06});
+    }
+    @include breakpoint(max) {
+      // grid margin + 96px column * 4 colums + gutter
+      left: -($spacing-06 + $spacing-12 * 4 + $spacing-05);
+    }
   }
 }
 

--- a/services/web-app/pages/assets/index/index.module.scss
+++ b/services/web-app/pages/assets/index/index.module.scss
@@ -83,11 +83,11 @@
       left: -($spacing-05 + $spacing-05);
     }
     @include breakpoint(lg) {
-      // grid margin + 6.25% column * 4 colums + gutter
+      // grid margin + 6.25% column * 4 columns + gutter
       left: calc(-25vw - #{$spacing-06});
     }
     @include breakpoint(max) {
-      // grid margin + 96px column * 4 colums + gutter
+      // grid margin + 96px column * 4 columns + gutter
       left: -($spacing-06 + $spacing-12 * 4 + $spacing-05);
     }
   }

--- a/services/web-app/pages/assets/index/index.module.scss
+++ b/services/web-app/pages/assets/index/index.module.scss
@@ -74,7 +74,7 @@
     position: absolute;
     top: 0;
     left: 0;
-    width: 100vw;
+    width: calc(100vw - var(--scrollbar-width));
     height: 100%;
     background: $layer-01;
     content: '';

--- a/services/web-app/pages/assets/index/index.module.scss
+++ b/services/web-app/pages/assets/index/index.module.scss
@@ -84,17 +84,17 @@
     height: 100%;
     background: theme.$layer-01;
     content: '';
-    @include breakpoint(md) {
+    @include breakpoint.breakpoint(md) {
       // grid margin + gutter
-      left: -($spacing-05 + $spacing-05);
+      left: -(spacing.$spacing-05 + spacing.$spacing-05);
     }
-    @include breakpoint(lg) {
+    @include breakpoint.breakpoint(lg) {
       // grid margin + 6.25% column * 4 columns + gutter
-      left: calc(-25vw - #{$spacing-06});
+      left: calc(-25vw - #{spacing.$spacing-06});
     }
-    @include breakpoint(max) {
+    @include breakpoint.breakpoint(max) {
       // grid margin + 96px column * 4 columns + gutter
-      left: -($spacing-06 + $spacing-12 * 4 + $spacing-05);
+      left: -(spacing.$spacing-06 + spacing.$spacing-12 * 4 + spacing.$spacing-05);
     }
   }
 }

--- a/services/web-app/styles/_base.scss
+++ b/services/web-app/styles/_base.scss
@@ -12,6 +12,10 @@
 
 html {
   box-sizing: border-box;
+  // This is a fallback in case the effect does not run in the Layout component. It can't be unit-
+  // less for the CSS custom property to be picked up.
+  /* stylelint-disable-next-line length-zero-no-unit */
+  --scrollbar-width: 0px;
 }
 
 html,


### PR DESCRIPTION
Closes #317 

When we built the asset landing page, we put `overflow:hidden` on the layout body to prevent horizontal scroll bars due to pseudo-element backgrounds and background SVG images (in the hero component.)

I just learned that `position:sticky` doesn't work if any parent is `overflow:hidden`. This PR removes the layout `overflow:hidden` and applies new styling in the assets landing page.

#### Changelog

**New**

- N/A

**Changed**

- Assets landing page highlights background pseudo element
- Hero background SVG positioning

**Removed**

- Layout `overflow:hidden`

#### Testing / reviewing

- Search and sort are sticky in asset catalogs again
- At all breakpoints, there's no horizontal scrolling in the assets landing page
- Hero background SVG positioning still looks good (this SVG will get updated to a new design soon - it's slightly different at extreme max viewport but I think that's okay until we receive those updated designs)
- Assets landing page highlights section has full width white background
