### PR TITLE
refactor: grid update for page without sidenav

### DIFF
--- a/services/web-app/layouts/layout/layout.js
+++ b/services/web-app/layouts/layout/layout.js
@@ -86,9 +86,9 @@ const Layout = ({ children }) => {
           </Theme>
           <Theme className={styles.body} theme="g10">
             <Grid as="main" className={styles.main} id="main-content">
-              <Column sm={4} md={8} lg={4}>
-                <Theme theme="white">
-                  {showSideNav && (
+              {showSideNav && (
+                <Column sm={4} md={8} lg={4}>
+                  <Theme theme="white">
                     <SideNav aria-label="Side navigation" expanded={isSideNavExpanded}>
                       <SideNavItems>
                         <HeaderSideNavItems>
@@ -132,10 +132,10 @@ const Layout = ({ children }) => {
                         })}
                       </SideNavItems>
                     </SideNav>
-                  )}
-                </Theme>
-              </Column>
-              <Column sm={4} md={8} lg={12}>
+                  </Theme>
+                </Column>
+              )}
+              <Column sm={4} md={8} lg={showSideNav ? 12 : 16}>
                 {children}
               </Column>
             </Grid>

--- a/services/web-app/pages/assets/[host]/[org]/[repo]/[library]/[ref]/[asset].js
+++ b/services/web-app/pages/assets/[host]/[org]/[repo]/[library]/[ref]/[asset].js
@@ -85,129 +85,137 @@ const Asset = ({ libraryData }) => {
   return (
     <>
       <NextSeo {...seo} />
-      <PageHeader title={seo.title} pictogram={get(type, `[${assetData.content.type}].icon`)} />
-      <PageBreadcrumb items={breadcrumbItems} />
-      <Dashboard className={styles.dashboard}>
-        <Column className={dashboardStyles.column} lg={1}>
-          <DashboardItem
-            aspectRatio={{ sm: '2x1', md: '1x1', lg: '3x4', xlg: '1x1' }}
-            border={['sm']}
-          >
-            <dl>
-              <dt className={dashboardStyles.label}>Library</dt>
-              <dd className={dashboardStyles.labelLarge}>{libraryData.content.name}</dd>
-            </dl>
-            <Link href={libraryPath}>
-              <a className={clsx(dashboardStyles.metaLink, dashboardStyles.metaLinkLarge)}>
-                {`v${libraryData.content.version}`}
-              </a>
-            </Link>
-            {SponsorIcon && (
-              <SponsorIcon
-                className={clsx(dashboardStyles.positionBottomLeft, styles.sponsorIcon)}
-                size={64}
+      <Grid>
+        <Column lg={{ start: 5, span: 12 }}>
+          <PageHeader title={seo.title} pictogram={get(type, `[${assetData.content.type}].icon`)} />
+          <PageBreadcrumb items={breadcrumbItems} />
+        </Column>
+        <Column lg={{ start: 5, span: 12 }}>
+          <Dashboard className={styles.dashboard}>
+            <Column className={dashboardStyles.column} lg={1}>
+              <DashboardItem
+                aspectRatio={{ sm: '2x1', md: '1x1', lg: '3x4', xlg: '1x1' }}
+                border={['sm']}
+              >
+                <dl>
+                  <dt className={dashboardStyles.label}>Library</dt>
+                  <dd className={dashboardStyles.labelLarge}>{libraryData.content.name}</dd>
+                </dl>
+                <Link href={libraryPath}>
+                  <a className={clsx(dashboardStyles.metaLink, dashboardStyles.metaLinkLarge)}>
+                    {`v${libraryData.content.version}`}
+                  </a>
+                </Link>
+                {SponsorIcon && (
+                  <SponsorIcon
+                    className={clsx(dashboardStyles.positionBottomLeft, styles.sponsorIcon)}
+                    size={64}
+                  />
+                )}
+              </DashboardItem>
+            </Column>
+            <Column className={dashboardStyles.column} lg={2}>
+              <DashboardItem aspectRatio={{ sm: '1x1', lg: 'none', xlg: 'none' }} border={['sm']}>
+                <Grid as="dl" columns={2} className={dashboardStyles.subgrid}>
+                  <Column className={dashboardStyles.subcolumn}>
+                    <dt className={dashboardStyles.label}>Sponsor</dt>
+                    <dd className={dashboardStyles.meta}>
+                      {get(teams, `[${assetData.params.sponsor}].name`, 'Community maintained')}
+                    </dd>
+                  </Column>
+                  <Column className={dashboardStyles.subcolumn}>
+                    <dt className={dashboardStyles.label}>Type</dt>
+                    <dd className={dashboardStyles.meta}>
+                      {get(type, `[${assetData.content.type}].name`, '–')}
+                    </dd>
+                  </Column>
+                  <Column className={dashboardStyles.subcolumn}>
+                    <dt className={dashboardStyles.label}>Framework</dt>
+                    <dd className={dashboardStyles.meta}>
+                      {get(framework, `[${assetData.content.framework}].name`, '–')}
+                    </dd>
+                  </Column>
+                  <Column className={dashboardStyles.subcolumn}>
+                    <dt className={dashboardStyles.label}>Status</dt>
+                    <dd className={dashboardStyles.meta}>
+                      <StatusIcon className={styles.statusIcon} status={assetData.content.status} />
+                      {get(status, `[${assetData.content.status}].name`, '–')}
+                    </dd>
+                  </Column>
+                  <Column
+                    className={clsx(dashboardStyles.subcolumn, dashboardStyles.subcolumnLinks)}
+                  >
+                    <dt className={clsx(dashboardStyles.label)}>Demos</dt>
+                    <dd className={dashboardStyles.meta}>
+                      <Link href={libraryPath}>
+                        <a className={dashboardStyles.metaLink}>Coming soon...</a>
+                      </Link>
+                    </dd>
+                  </Column>
+                  <Column className={dashboardStyles.subcolumn}>
+                    <dt className={dashboardStyles.label}>Tags</dt>
+                    <dd className={dashboardStyles.meta}>Coming soon...</dd>
+                  </Column>
+                  <Button className={styles.kitsButton}>
+                    Coming soon...
+                    <ArrowRight size={16} />
+                  </Button>
+                </Grid>
+              </DashboardItem>
+            </Column>
+            <Column className={dashboardStyles.column} sm={0} md={1}>
+              <DashboardItem
+                aspectRatio={{ md: '2x1', lg: '16x9', xlg: '2x1' }}
+                border={['sm', 'md', 'lg', 'xlg']}
+              >
+                <dl>
+                  <dt className={dashboardStyles.label}>Coming soon...</dt>
+                  <dd className={dashboardStyles.labelLarge}>–</dd>
+                </dl>
+              </DashboardItem>
+            </Column>
+            <Column className={dashboardStyles.column} sm={0} md={1}>
+              <DashboardItem
+                aspectRatio={{ md: '2x1', lg: '16x9', xlg: '2x1' }}
+                border={['sm', 'md', 'lg', 'xlg']}
+                href={libraryPath}
+              >
+                <dl>
+                  <dt className={dashboardStyles.label}>Coming soon...</dt>
+                  <dd className={dashboardStyles.labelLarge}>–</dd>
+                </dl>
+                <Svg32Github className={dashboardStyles.positionBottomLeft} />
+                {pathIsAbsolute(libraryPath) && (
+                  <Launch className={dashboardStyles.positionBottomRight} size={20} />
+                )}
+              </DashboardItem>
+            </Column>
+            <Column className={dashboardStyles.column} sm={0} md={1}>
+              <DashboardItem
+                aspectRatio={{ md: '2x1', lg: '16x9', xlg: '2x1' }}
+                border={['sm', 'md', 'lg', 'xlg']}
+                href="https://carbondesignsystem.com"
+              >
+                <dl>
+                  <dt className={dashboardStyles.label}>Coming soon...</dt>
+                  <dd className={dashboardStyles.labelLarge}>–</dd>
+                </dl>
+                <Svg32Github className={dashboardStyles.positionBottomLeft} />
+                {pathIsAbsolute('https://carbondesignsystem.com') && (
+                  <Launch className={dashboardStyles.positionBottomRight} size={20} />
+                )}
+              </DashboardItem>
+            </Column>
+            <Column className={dashboardStyles.column} sm={0} md={1} lg={0}>
+              <DashboardItem
+                aspectRatio={{ md: '2x1', lg: '16x9', xlg: '2x1' }}
+                border={['sm', 'md', 'lg', 'xlg']}
+                spacer
               />
-            )}
-          </DashboardItem>
+            </Column>
+          </Dashboard>
         </Column>
-        <Column className={dashboardStyles.column} lg={2}>
-          <DashboardItem aspectRatio={{ sm: '1x1', lg: 'none', xlg: 'none' }} border={['sm']}>
-            <Grid as="dl" columns={2} className={dashboardStyles.subgrid}>
-              <Column className={dashboardStyles.subcolumn}>
-                <dt className={dashboardStyles.label}>Sponsor</dt>
-                <dd className={dashboardStyles.meta}>
-                  {get(teams, `[${assetData.params.sponsor}].name`, 'Community maintained')}
-                </dd>
-              </Column>
-              <Column className={dashboardStyles.subcolumn}>
-                <dt className={dashboardStyles.label}>Type</dt>
-                <dd className={dashboardStyles.meta}>
-                  {get(type, `[${assetData.content.type}].name`, '–')}
-                </dd>
-              </Column>
-              <Column className={dashboardStyles.subcolumn}>
-                <dt className={dashboardStyles.label}>Framework</dt>
-                <dd className={dashboardStyles.meta}>
-                  {get(framework, `[${assetData.content.framework}].name`, '–')}
-                </dd>
-              </Column>
-              <Column className={dashboardStyles.subcolumn}>
-                <dt className={dashboardStyles.label}>Status</dt>
-                <dd className={dashboardStyles.meta}>
-                  <StatusIcon className={styles.statusIcon} status={assetData.content.status} />
-                  {get(status, `[${assetData.content.status}].name`, '–')}
-                </dd>
-              </Column>
-              <Column className={clsx(dashboardStyles.subcolumn, dashboardStyles.subcolumnLinks)}>
-                <dt className={clsx(dashboardStyles.label)}>Demos</dt>
-                <dd className={dashboardStyles.meta}>
-                  <Link href={libraryPath}>
-                    <a className={dashboardStyles.metaLink}>Coming soon...</a>
-                  </Link>
-                </dd>
-              </Column>
-              <Column className={dashboardStyles.subcolumn}>
-                <dt className={dashboardStyles.label}>Tags</dt>
-                <dd className={dashboardStyles.meta}>Coming soon...</dd>
-              </Column>
-              <Button className={styles.kitsButton}>
-                Coming soon...
-                <ArrowRight size={16} />
-              </Button>
-            </Grid>
-          </DashboardItem>
-        </Column>
-        <Column className={dashboardStyles.column} sm={0} md={1}>
-          <DashboardItem
-            aspectRatio={{ md: '2x1', lg: '16x9', xlg: '2x1' }}
-            border={['sm', 'md', 'lg', 'xlg']}
-          >
-            <dl>
-              <dt className={dashboardStyles.label}>Coming soon...</dt>
-              <dd className={dashboardStyles.labelLarge}>–</dd>
-            </dl>
-          </DashboardItem>
-        </Column>
-        <Column className={dashboardStyles.column} sm={0} md={1}>
-          <DashboardItem
-            aspectRatio={{ md: '2x1', lg: '16x9', xlg: '2x1' }}
-            border={['sm', 'md', 'lg', 'xlg']}
-            href={libraryPath}
-          >
-            <dl>
-              <dt className={dashboardStyles.label}>Coming soon...</dt>
-              <dd className={dashboardStyles.labelLarge}>–</dd>
-            </dl>
-            <Svg32Github className={dashboardStyles.positionBottomLeft} />
-            {pathIsAbsolute(libraryPath) && (
-              <Launch className={dashboardStyles.positionBottomRight} size={20} />
-            )}
-          </DashboardItem>
-        </Column>
-        <Column className={dashboardStyles.column} sm={0} md={1}>
-          <DashboardItem
-            aspectRatio={{ md: '2x1', lg: '16x9', xlg: '2x1' }}
-            border={['sm', 'md', 'lg', 'xlg']}
-            href="https://carbondesignsystem.com"
-          >
-            <dl>
-              <dt className={dashboardStyles.label}>Coming soon...</dt>
-              <dd className={dashboardStyles.labelLarge}>–</dd>
-            </dl>
-            <Svg32Github className={dashboardStyles.positionBottomLeft} />
-            {pathIsAbsolute('https://carbondesignsystem.com') && (
-              <Launch className={dashboardStyles.positionBottomRight} size={20} />
-            )}
-          </DashboardItem>
-        </Column>
-        <Column className={dashboardStyles.column} sm={0} md={1} lg={0}>
-          <DashboardItem
-            aspectRatio={{ md: '2x1', lg: '16x9', xlg: '2x1' }}
-            border={['sm', 'md', 'lg', 'xlg']}
-            spacer
-          />
-        </Column>
-      </Dashboard>
+      </Grid>
     </>
   )
 }

--- a/services/web-app/pages/assets/[host]/[org]/[repo]/[library]/[ref]/[asset].js
+++ b/services/web-app/pages/assets/[host]/[org]/[repo]/[library]/[ref]/[asset].js
@@ -86,11 +86,11 @@ const Asset = ({ libraryData }) => {
     <>
       <NextSeo {...seo} />
       <Grid>
-        <Column lg={{ start: 5, span: 12 }}>
+        <Column sm={4} md={8} lg={{ start: 5, span: 12 }}>
           <PageHeader title={seo.title} pictogram={get(type, `[${assetData.content.type}].icon`)} />
           <PageBreadcrumb items={breadcrumbItems} />
         </Column>
-        <Column lg={{ start: 5, span: 12 }}>
+        <Column sm={4} md={8} lg={{ start: 5, span: 12 }}>
           <Dashboard className={styles.dashboard}>
             <Column className={dashboardStyles.column} lg={1}>
               <DashboardItem

--- a/services/web-app/pages/assets/[host]/[org]/[repo]/[library]/[ref]/index.js
+++ b/services/web-app/pages/assets/[host]/[org]/[repo]/[library]/[ref]/index.js
@@ -70,68 +70,79 @@ const Library = ({ libraryData, params }) => {
   return (
     <>
       <NextSeo {...seo} />
-      <PageHeader title={seo.title} pictogram={FileBackup} />
-      <PageBreadcrumb items={breadcrumbItems} />
-      <Dashboard className={styles.dashboard}>
-        <Column className={dashboardStyles.column} lg={1}>
-          <DashboardItem
-            aspectRatio={{ sm: '2x1', md: '1x1', lg: '3x4', xlg: '1x1' }}
-            border={['sm']}
-          >
-            <dl>
-              <dt className={dashboardStyles.label}>Version</dt>
-              <dd className={dashboardStyles.labelLarge}>{`v${libraryData.content.version}`}</dd>
-            </dl>
-            {SponsorIcon && (
-              <SponsorIcon
-                className={clsx(dashboardStyles.positionBottomLeft, styles.sponsorIcon)}
-                size={64}
-              />
-            )}
-          </DashboardItem>
+      <Grid>
+        <Column lg={{ start: 5, span: 12 }}>
+          <PageHeader title={seo.title} pictogram={FileBackup} />
+          <PageBreadcrumb items={breadcrumbItems} />
         </Column>
-        <Column className={dashboardStyles.column} lg={2}>
-          <DashboardItem aspectRatio={{ sm: '1x1', lg: 'none', xlg: 'none' }} border={['sm']}>
-            <Grid as="dl" columns={2} className={dashboardStyles.subgrid}>
-              <Column className={dashboardStyles.subcolumn}>
-                <dt className={dashboardStyles.label}>Sponsor</dt>
-                <dd className={dashboardStyles.meta}>
-                  {get(teams, `[${libraryData.params.sponsor}].name`, 'Community maintained')}
-                </dd>
-              </Column>
-              <Column className={dashboardStyles.subcolumn}>
-                <dt className={dashboardStyles.label}>License</dt>
-                <dd className={dashboardStyles.meta}>{getLicense(libraryData)}</dd>
-              </Column>
-              <Column className={clsx(dashboardStyles.subcolumn, dashboardStyles.subcolumnLinks)}>
-                <dt className={clsx(dashboardStyles.label)}>Demos</dt>
-                <dd className={dashboardStyles.meta}>
-                  <Link href="https://carbondesignsystem.com">
-                    <a className={dashboardStyles.metaLink}>Coming soon...</a>
-                  </Link>
-                </dd>
-              </Column>
-              <Button className={styles.versionsButton}>
-                Coming soon...
-                <ArrowRight size={16} />
-              </Button>
-            </Grid>
-          </DashboardItem>
-        </Column>
-      </Dashboard>
-      <div className={pageStyles.content}>
-        <ul>
-          {assets.map((asset, i) => (
-            <li key={i}>
-              <Link
-                href={`/assets/${asset.params.library}/${params.ref}/${getSlug(asset.content)}`}
+        <Column lg={4}>{/* In page nav  */}</Column>
+        <Column lg={12}>
+          <Dashboard className={styles.dashboard}>
+            <Column className={dashboardStyles.column} lg={1}>
+              <DashboardItem
+                aspectRatio={{ sm: '2x1', md: '1x1', lg: '3x4', xlg: '1x1' }}
+                border={['sm']}
               >
-                <a>{asset.content.name || 'Asset'}</a>
-              </Link>
-            </li>
-          ))}
-        </ul>
-      </div>
+                <dl>
+                  <dt className={dashboardStyles.label}>Version</dt>
+                  <dd
+                    className={dashboardStyles.labelLarge}
+                  >{`v${libraryData.content.version}`}</dd>
+                </dl>
+                {SponsorIcon && (
+                  <SponsorIcon
+                    className={clsx(dashboardStyles.positionBottomLeft, styles.sponsorIcon)}
+                    size={64}
+                  />
+                )}
+              </DashboardItem>
+            </Column>
+            <Column className={dashboardStyles.column} lg={2}>
+              <DashboardItem aspectRatio={{ sm: '1x1', lg: 'none', xlg: 'none' }} border={['sm']}>
+                <Grid as="dl" columns={2} className={dashboardStyles.subgrid}>
+                  <Column className={dashboardStyles.subcolumn}>
+                    <dt className={dashboardStyles.label}>Sponsor</dt>
+                    <dd className={dashboardStyles.meta}>
+                      {get(teams, `[${libraryData.params.sponsor}].name`, 'Community maintained')}
+                    </dd>
+                  </Column>
+                  <Column className={dashboardStyles.subcolumn}>
+                    <dt className={dashboardStyles.label}>License</dt>
+                    <dd className={dashboardStyles.meta}>{getLicense(libraryData)}</dd>
+                  </Column>
+                  <Column
+                    className={clsx(dashboardStyles.subcolumn, dashboardStyles.subcolumnLinks)}
+                  >
+                    <dt className={clsx(dashboardStyles.label)}>Demos</dt>
+                    <dd className={dashboardStyles.meta}>
+                      <Link href="https://carbondesignsystem.com">
+                        <a className={dashboardStyles.metaLink}>Coming soon...</a>
+                      </Link>
+                    </dd>
+                  </Column>
+                  <Button className={styles.versionsButton}>
+                    Coming soon...
+                    <ArrowRight size={16} />
+                  </Button>
+                </Grid>
+              </DashboardItem>
+            </Column>
+          </Dashboard>
+          <div className={pageStyles.content}>
+            <ul>
+              {assets.map((asset, i) => (
+                <li key={i}>
+                  <Link
+                    href={`/assets/${asset.params.library}/${params.ref}/${getSlug(asset.content)}`}
+                  >
+                    <a>{asset.content.name || 'Asset'}</a>
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </Column>
+      </Grid>
     </>
   )
 }

--- a/services/web-app/pages/assets/[host]/[org]/[repo]/[library]/[ref]/index.js
+++ b/services/web-app/pages/assets/[host]/[org]/[repo]/[library]/[ref]/index.js
@@ -71,12 +71,14 @@ const Library = ({ libraryData, params }) => {
     <>
       <NextSeo {...seo} />
       <Grid>
-        <Column lg={{ start: 5, span: 12 }}>
+        <Column sm={4} md={8} lg={{ start: 5, span: 12 }}>
           <PageHeader title={seo.title} pictogram={FileBackup} />
           <PageBreadcrumb items={breadcrumbItems} />
         </Column>
-        <Column lg={4}>{/* In page nav  */}</Column>
-        <Column lg={12}>
+        <Column sm={4} md={8} lg={4}>
+          {/* In page nav  */}
+        </Column>
+        <Column sm={4} md={8} lg={12}>
           <Dashboard className={styles.dashboard}>
             <Column className={dashboardStyles.column} lg={1}>
               <DashboardItem


### PR DESCRIPTION
Ref #385

In order to add the in page nav to the library pages we need to update the grid to span the full 16 columns on pages without a sidenav. 

#### Changelog

**Changed**

- Updates layout to not have an empty column when there is no sidenav
- Updates library detail and asset detail page grid to add left column for future content

#### Testing / reviewing

Make sure nothing changed with the grid on any pages. 
