### PR TITLE
fix: link style on asset detail page

### DIFF
--- a/services/web-app/pages/assets/[host]/[org]/[repo]/[library]/[ref]/[asset].js
+++ b/services/web-app/pages/assets/[host]/[org]/[repo]/[library]/[ref]/[asset].js
@@ -111,7 +111,7 @@ const Asset = ({ libraryData }) => {
                   <dt className={dashboardStyles.label}>Library</dt>
                   <dd className={dashboardStyles.labelLarge}>{libraryData.content.name}</dd>
                 </dl>
-                <Link href={libraryPath} passHref={true}>
+                <Link href={libraryPath} passHref>
                   <CarbonLink className={clsx(dashboardStyles.metaLinkLarge)}>
                     {`v${libraryData.content.version}`}
                   </CarbonLink>

--- a/services/web-app/pages/assets/[host]/[org]/[repo]/[library]/[ref]/[asset].js
+++ b/services/web-app/pages/assets/[host]/[org]/[repo]/[library]/[ref]/[asset].js
@@ -112,7 +112,7 @@ const Asset = ({ libraryData }) => {
                   <dd className={dashboardStyles.labelLarge}>{libraryData.content.name}</dd>
                 </dl>
                 <Link href={libraryPath} passHref>
-                  <CarbonLink className={clsx(dashboardStyles.metaLinkLarge)}>
+                  <CarbonLink className={dashboardStyles.metaLinkLarge}>
                     {`v${libraryData.content.version}`}
                   </CarbonLink>
                 </Link>

--- a/services/web-app/pages/assets/[host]/[org]/[repo]/[library]/[ref]/[asset].js
+++ b/services/web-app/pages/assets/[host]/[org]/[repo]/[library]/[ref]/[asset].js
@@ -112,7 +112,7 @@ const Asset = ({ libraryData }) => {
                   <dd className={dashboardStyles.labelLarge}>{libraryData.content.name}</dd>
                 </dl>
                 <Link href={libraryPath}>
-                  <a className={clsx(dashboardStyles.metaLink, dashboardStyles.metaLinkLarge)}>
+                  <a className={clsx('cds--link', dashboardStyles.metaLinkLarge)}>
                     {`v${libraryData.content.version}`}
                   </a>
                 </Link>

--- a/services/web-app/pages/assets/[host]/[org]/[repo]/[library]/[ref]/[asset].js
+++ b/services/web-app/pages/assets/[host]/[org]/[repo]/[library]/[ref]/[asset].js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { Button, Column, Grid, Link as CarbonLink  } from '@carbon/react'
+import { Button, Column, Grid, Link as CarbonLink } from '@carbon/react'
 import { ArrowRight, Events, Launch } from '@carbon/react/icons'
 import { Svg32Github } from '@carbon-platform/icons'
 import clsx from 'clsx'

--- a/services/web-app/pages/assets/[host]/[org]/[repo]/[library]/[ref]/[asset].js
+++ b/services/web-app/pages/assets/[host]/[org]/[repo]/[library]/[ref]/[asset].js
@@ -111,7 +111,7 @@ const Asset = ({ libraryData }) => {
                   <dt className={dashboardStyles.label}>Library</dt>
                   <dd className={dashboardStyles.labelLarge}>{libraryData.content.name}</dd>
                 </dl>
-                <Link href={libraryPath}>
+                <Link href={libraryPath} passHref={true}>
                   <CarbonLink className={clsx(dashboardStyles.metaLinkLarge)}>
                     {`v${libraryData.content.version}`}
                   </CarbonLink>

--- a/services/web-app/pages/assets/[host]/[org]/[repo]/[library]/[ref]/[asset].js
+++ b/services/web-app/pages/assets/[host]/[org]/[repo]/[library]/[ref]/[asset].js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { Button, Column, Grid } from '@carbon/react'
+import { Button, Column, Grid, Link as CarbonLink  } from '@carbon/react'
 import { ArrowRight, Events, Launch } from '@carbon/react/icons'
 import { Svg32Github } from '@carbon-platform/icons'
 import clsx from 'clsx'
@@ -112,9 +112,9 @@ const Asset = ({ libraryData }) => {
                   <dd className={dashboardStyles.labelLarge}>{libraryData.content.name}</dd>
                 </dl>
                 <Link href={libraryPath}>
-                  <a className={clsx('cds--link', dashboardStyles.metaLinkLarge)}>
+                  <CarbonLink className={clsx(dashboardStyles.metaLinkLarge)}>
                     {`v${libraryData.content.version}`}
-                  </a>
+                  </CarbonLink>
                 </Link>
                 {SponsorIcon && (
                   <SponsorIcon


### PR DESCRIPTION
Bug noticed during dev sync



<img width="471" alt="Screen Shot 2022-03-22 at 12 03 45 PM" src="https://user-images.githubusercontent.com/2753488/159535463-6f3c6be4-7f4e-4db7-8ae9-b5f1d45899a5.png">


#### Changelog


**Changed**

Updated class name on meta link large to use default Carbon link styles

#### Testing / reviewing

Check link style on asset detail page
<img width="481" alt="Screen Shot 2022-03-22 at 12 02 38 PM" src="https://user-images.githubusercontent.com/2753488/159535213-04e9239d-ee66-4279-83e1-cadc35565da6.png">
