### PR TITLE
fix: storybook layout for next pages

### DIFF
--- a/services/web-app/.storybook/layout.js
+++ b/services/web-app/.storybook/layout.js
@@ -1,0 +1,41 @@
+/*
+ * Copyright IBM Corp. 2022, 2022
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import Layout, { LayoutProvider } from '@/layouts/layout'
+
+export const pageConfig = {
+  decorators: [
+    (Story, context) => {
+      const { layout } = context.globals
+
+      // offset the global decorator to effectively ignore the custom layout (never have a padded
+      // storybook preview for full Next.js pages)
+      const style = {
+        margin: layout === 'padded' ? '-1rem' : 0
+      }
+
+      return (
+        <div style={style}>
+          <Story {...context} />
+        </div>
+      )
+    }
+  ],
+  parameters: {
+    options: { showPanel: false },
+    previewTabs: {
+      'storybook/docs/panel': { hidden: true }
+    },
+    viewMode: 'canvas'
+  }
+}
+
+export const PageLayout = ({ args, children }) => (
+  <LayoutProvider {...args}>
+    <Layout>{children}</Layout>
+  </LayoutProvider>
+)

--- a/services/web-app/.storybook/preview.js
+++ b/services/web-app/.storybook/preview.js
@@ -35,15 +35,21 @@ export const decorators = [
   (Story, context) => {
     const { layout, theme } = context.globals
 
+    // padded layout, set background and internal padding because storybook is configured fullscreen
+    const style = {
+      background: 'var(--cds-background)',
+      padding: '1rem'
+    }
+
+    // fullscreen layout, margin collapse for compoents with top margins
+    if (layout === 'fullscreen') {
+      style.margin = '-1px'
+      style.padding = '1px'
+    }
+
     return (
       <Theme theme={theme}>
-        <div
-          style={{
-            background: 'var(--cds-background)',
-            padding: layout === 'fullscreen' ? '1px' : '1rem',
-            margin: '-1px'
-          }}
-        >
+        <div style={style}>
           <Story {...context} />
         </div>
       </Theme>

--- a/services/web-app/stories/mdx/accordion.stories.js
+++ b/services/web-app/stories/mdx/accordion.stories.js
@@ -11,9 +11,7 @@ import { Accordion, AccordionItem } from '@/components/accordion'
 const stories = {
   title: 'MDX/Accordion',
   component: Accordion,
-  subcomponents: { AccordionItem },
-  argTypes: {},
-  parameters: {}
+  subcomponents: { AccordionItem }
 }
 
 export default stories

--- a/services/web-app/stories/mdx/anchor-links.stories.js
+++ b/services/web-app/stories/mdx/anchor-links.stories.js
@@ -16,8 +16,7 @@ const stories = {
     small: {
       control: 'boolean'
     }
-  },
-  parameters: {}
+  }
 }
 
 export default stories

--- a/services/web-app/stories/pages/404.stories.js
+++ b/services/web-app/stories/pages/404.stories.js
@@ -5,29 +5,22 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import Layout, { LayoutProvider } from '@/layouts/layout'
 import FourOhFour from '@/pages/404.js'
+
+import { pageConfig, PageLayout } from '../../.storybook/layout'
 
 const stories = {
   title: 'Platform/Pages/404',
   component: FourOhFour,
-  parameters: {
-    options: { showPanel: false },
-    previewTabs: {
-      'storybook/docs/panel': { hidden: true }
-    },
-    viewMode: 'canvas'
-  }
+  ...pageConfig
 }
 
 export default stories
 
 const Template = (args) => (
-  <LayoutProvider {...args}>
-    <Layout>
-      <FourOhFour />
-    </Layout>
-  </LayoutProvider>
+  <PageLayout args={args}>
+    <FourOhFour />
+  </PageLayout>
 )
 
 export const Default = Template.bind({})

--- a/services/web-app/stories/pages/assets.stories.js
+++ b/services/web-app/stories/pages/assets.stories.js
@@ -5,29 +5,22 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import Layout, { LayoutProvider } from '@/layouts/layout'
 import Assets from '@/pages/assets/index.js'
+
+import { pageConfig, PageLayout } from '../../.storybook/layout'
 
 const stories = {
   title: 'Platform/Pages/Assets',
   component: Assets,
-  parameters: {
-    options: { showPanel: false },
-    previewTabs: {
-      'storybook/docs/panel': { hidden: true }
-    },
-    viewMode: 'canvas'
-  }
+  ...pageConfig
 }
 
 export default stories
 
 const Template = (args) => (
-  <LayoutProvider {...args}>
-    <Layout>
-      <Assets />
-    </Layout>
-  </LayoutProvider>
+  <PageLayout args={args}>
+    <Assets />
+  </PageLayout>
 )
 
 export const Default = Template.bind({})


### PR DESCRIPTION
We have a custom layout global control to set full screen or padded. We don't use the out-of-box Storybook layout options because we're setting a global theme (e.g. g10) and we need the padding to be inside that, not around it.

<img width="844" alt="image" src="https://user-images.githubusercontent.com/1691245/165536262-837122b8-f425-4cd2-b56e-08aff5a72ca0.png">

This PR:

- Adds comments to the full screen / padded custom global styling
- Ensures the "page" stories always renders full screen because if the preview is padded, it pushes page content in and will lead to falsely-reported bugs
- Moves "page" story config and layout wrapper components to a new `layout.js` file