### PR TITLE
fix(web-app): update dashboard card border

### DIFF
--- a/services/web-app/components/dashboard/dashboard-item.js
+++ b/services/web-app/components/dashboard/dashboard-item.js
@@ -18,7 +18,6 @@ import styles from './dashboard-item.module.scss'
 export const DashboardItem = ({
   as: element = 'span',
   aspectRatio = {},
-  border = [],
   children,
   href,
   spacer: showSpacer
@@ -32,10 +31,6 @@ export const DashboardItem = ({
   if (isLg) ratio = aspectRatio.lg
   if (isXlg) ratio = aspectRatio.xlg
 
-  let showBorder = !isMd ? border.includes('sm') : border.includes('md')
-  if (isLg) showBorder = border.includes('lg')
-  if (isXlg) showBorder = border.includes('xlg')
-
   const Element = isEmpty(aspectRatio) || ratio === 'none' ? element : AspectRatio
   const props = {}
 
@@ -48,14 +43,7 @@ export const DashboardItem = ({
   }
 
   const renderElement = () => (
-    <Element
-      className={clsx(
-        styles.element,
-        showBorder && styles['element--border'],
-        showSpacer && styles['element--spacer']
-      )}
-      {...props}
-    >
+    <Element className={clsx(styles.element, showSpacer && styles['element--spacer'])} {...props}>
       {children}
     </Element>
   )
@@ -74,7 +62,6 @@ export const DashboardItem = ({
 DashboardItem.propTypes = {
   as: PropTypes.string,
   aspectRatio: PropTypes.object,
-  border: PropTypes.array,
   children: PropTypes.node,
   href: PropTypes.string,
   spacer: PropTypes.any

--- a/services/web-app/components/dashboard/dashboard-item.module.scss
+++ b/services/web-app/components/dashboard/dashboard-item.module.scss
@@ -22,11 +22,6 @@
   background: theme.$layer-01;
   transition: background motion.$duration-fast-02 motion.motion(standard, productive);
 
-  &--border {
-    outline: 1px solid theme.$background;
-    outline-offset: 0;
-  }
-
   &--spacer {
     background: theme.$background;
   }

--- a/services/web-app/components/dashboard/dashboard.module.scss
+++ b/services/web-app/components/dashboard/dashboard.module.scss
@@ -23,6 +23,24 @@
   margin-left: -(spacing.$spacing-05);
 }
 
+.column {
+  border-top: 1px solid theme.$border-subtle;
+
+  &:first-child {
+    border-top: none;
+  }
+
+  @include breakpoint.breakpoint('md') {
+    &:nth-child(2) {
+      border-top: none;
+    }
+
+    &:nth-child(even) {
+      box-shadow: -1px 0 0 0 theme.$border-subtle;
+    }
+  }
+}
+
 .subcolumn {
   &--links {
     display: flex;

--- a/services/web-app/pages/assets/[host]/[org]/[repo]/[library]/[ref]/[asset].js
+++ b/services/web-app/pages/assets/[host]/[org]/[repo]/[library]/[ref]/[asset].js
@@ -153,10 +153,7 @@ const Asset = ({ libraryData }) => {
           <section id="glance">
             <Dashboard className={styles.dashboard}>
               <Column className={dashboardStyles.column} sm={4}>
-                <DashboardItem
-                  aspectRatio={{ sm: '2x1', md: '1x1', lg: '3x4', xlg: '1x1' }}
-                  border={['sm']}
-                >
+                <DashboardItem aspectRatio={{ sm: '2x1', md: '1x1', lg: '3x4', xlg: '1x1' }}>
                   <dl>
                     <dt className={dashboardStyles.label}>Library</dt>
                     <dd className={dashboardStyles['label--large']}>{libraryData.content.name}</dd>
@@ -178,7 +175,7 @@ const Asset = ({ libraryData }) => {
                 </DashboardItem>
               </Column>
               <Column className={dashboardStyles.column} sm={4} lg={8}>
-                <DashboardItem aspectRatio={{ sm: '1x1', lg: 'none', xlg: 'none' }} border={['sm']}>
+                <DashboardItem aspectRatio={{ sm: '1x1', lg: 'none', xlg: 'none' }}>
                   <Grid as="dl" className={dashboardStyles.subgrid}>
                     <Column className={dashboardStyles.subcolumn} sm={2} lg={4}>
                       <dt className={dashboardStyles.label}>Sponsor</dt>
@@ -239,7 +236,6 @@ const Asset = ({ libraryData }) => {
               <Column className={dashboardStyles.column} sm={0} md={4}>
                 <DashboardItem
                   aspectRatio={{ md: '2x1', lg: '16x9', xlg: '2x1' }}
-                  border={['sm', 'md', 'lg', 'xlg']}
                   href={`${githubRepoUrl}/issues/?q=is%3Aissue+is%3Aopen+in%3Atitle+${assetData.content.name}`}
                 >
                   <dl>
@@ -257,7 +253,6 @@ const Asset = ({ libraryData }) => {
               <Column className={dashboardStyles.column} sm={0} md={4}>
                 <DashboardItem
                   aspectRatio={{ md: '2x1', lg: '16x9', xlg: '2x1' }}
-                  border={['sm', 'md', 'lg', 'xlg']}
                   href={`${githubRepoUrl}/discussions/?discussions_q=in%3Atitle+${assetData.content.id}`}
                 >
                   <dl>

--- a/services/web-app/pages/assets/[host]/[org]/[repo]/[library]/[ref]/index.js
+++ b/services/web-app/pages/assets/[host]/[org]/[repo]/[library]/[ref]/index.js
@@ -79,10 +79,7 @@ const Library = ({ libraryData, params }) => {
         <Column sm={4} md={8} lg={12}>
           <Dashboard className={styles.dashboard}>
             <Column className={dashboardStyles.column} sm={4}>
-              <DashboardItem
-                aspectRatio={{ sm: '2x1', md: '1x1', lg: '3x4', xlg: '1x1' }}
-                border={['sm']}
-              >
+              <DashboardItem aspectRatio={{ sm: '2x1', md: '1x1', lg: '3x4', xlg: '1x1' }}>
                 <dl>
                   <dt className={dashboardStyles.label}>Version</dt>
                   <dd
@@ -101,7 +98,7 @@ const Library = ({ libraryData, params }) => {
               </DashboardItem>
             </Column>
             <Column className={dashboardStyles.column} sm={4} lg={8}>
-              <DashboardItem aspectRatio={{ sm: '1x1', lg: 'none', xlg: 'none' }} border={['sm']}>
+              <DashboardItem aspectRatio={{ sm: '1x1', lg: 'none', xlg: 'none' }}>
                 <Grid as="dl" className={dashboardStyles.subgrid}>
                   <Column className={dashboardStyles.subcolumn} sm={2} lg={4}>
                     <dt className={dashboardStyles.label}>Sponsor</dt>

--- a/services/web-app/pages/assets/index.js
+++ b/services/web-app/pages/assets/index.js
@@ -245,7 +245,6 @@ const PageContent = () => {
               <DashboardItem
                 href="/assets/components"
                 aspectRatio={{ sm: '3x2', md: '4x3', lg: '3x2', xlg: '2x1' }}
-                border={['sm', 'md', 'lg', 'xlg']}
               >
                 <dl>
                   <dt className={styles['dashboard-label']}>Components</dt>
@@ -268,7 +267,6 @@ const PageContent = () => {
             <Column className={dashboardStyles.column} sm={4} lg={6}>
               <DashboardItem
                 aspectRatio={{ sm: '3x2', md: '4x3', lg: '3x2', xlg: '2x1' }}
-                border={['sm', 'md', 'lg', 'xlg']}
                 href="/assets/patterns"
               >
                 <dl>
@@ -291,7 +289,6 @@ const PageContent = () => {
             <Column className={dashboardStyles.column} sm={4} lg={6}>
               <DashboardItem
                 aspectRatio={{ sm: '3x2', md: '4x3', lg: '3x2', xlg: '2x1' }}
-                border={['sm', 'md', 'lg', 'xlg']}
                 href="/assets/functions"
               >
                 <dl>


### PR DESCRIPTION
Closes #491 

Move border logic from js to css, update border to be border-subtle token

#### Changelog

**New**

- updated css to show correct border inbetween cards

**Removed**

- border prop from DashboardItem component
- old border css

#### Testing / reviewing

Test at all breakpoints, border should be gray-30 (border-subtle) only inbetween cards, not on top or side edges.

http://localhost:3000/assets
http://localhost:3000/assets/carbon-charts
http://localhost:3000/assets/carbon-charts/latest/alluvial
<img width="1190" alt="Screen Shot 2022-05-11 at 3 49 35 PM" src="https://user-images.githubusercontent.com/2753488/167945177-23ca4ef0-3e6f-42ee-8eac-45df187b3591.png">


<img width="816" alt="Screen Shot 2022-05-11 at 3 47 57 PM" src="https://user-images.githubusercontent.com/2753488/167944952-23e31301-30a3-4098-9319-fa3d36068755.png">

