### PR TITLE
fix(web-app): page title descender clipped

### DIFF
--- a/services/web-app/components/page-header/page-header.module.scss
+++ b/services/web-app/components/page-header/page-header.module.scss
@@ -51,6 +51,13 @@ $page-header-height: spacing.$spacing-13 * 2;
 
     font-family: type.font-family('sans');
   }
+
+  // fix for title descender being clipped at xlg breakpoint
+  @include breakpoint.breakpoint(xlg) {
+    position: relative;
+    top: spacing.$spacing-01;
+    padding-bottom: spacing.$spacing-01;
+  }
 }
 
 .pictogram {


### PR DESCRIPTION
Closes #261 



#### Testing / reviewing

Check that page title descender on letter **g** isn't being clipped at the bottom
http://localhost:3000/assets/carbon-charts-angular
