### PR TITLE
fix(web-app): sticky position for typesetstyle and colortokentable

### DIFF
--- a/services/web-app/components/color-token-table/color-token-table.js
+++ b/services/web-app/components/color-token-table/color-token-table.js
@@ -31,10 +31,11 @@ const ColorTokenTable = () => {
   const [mobile, setMobile] = useState(false)
 
   // Conditionally add a drop shadow through JavaScript because `position:sticky` doesn't support a
-  // `::stuck` pseudo-class to trigger the drop shadow. Header (48) + spacer (16)  = 64.
+  // `::stuck` pseudo-class to trigger the drop shadow.
+  // Header (48) + spacer (16) ) + tabs(48)  = 112.
   const scrollHandler = useCallback(() => {
     if (containerRef.current && typeof window !== 'undefined') {
-      setIsSticky(containerRef.current.getBoundingClientRect().top === 64)
+      setIsSticky(containerRef.current.getBoundingClientRect().top === 112)
     }
   }, [])
 

--- a/services/web-app/components/typeset-style/typeset-style.js
+++ b/services/web-app/components/typeset-style/typeset-style.js
@@ -62,10 +62,11 @@ const TypesetStyle = ({
   })
 
   // Conditionally add a drop shadow through JavaScript because `position:sticky` doesn't support a
-  // `::stuck` pseudo-class to trigger the drop shadow. Header (48) + spacer (16)  = 64.
+  // `::stuck` pseudo-class to trigger the drop shadow.
+  // Header (48) + spacer (16) + tabs(48)  = 112.
   const scrollHandler = useCallback(() => {
     if (containerRef.current && typeof window !== 'undefined') {
-      setSticky(containerRef.current.getBoundingClientRect().top === 64)
+      setSticky(containerRef.current.getBoundingClientRect().top === 112)
     }
   }, [])
 

--- a/services/web-app/components/typeset-style/typeset-style.module.scss
+++ b/services/web-app/components/typeset-style/typeset-style.module.scss
@@ -332,7 +332,8 @@
 }
 
 .sticky-container-visible {
-  top: 7rem;
+  // Header (48) + spacer (16) + tabs(48)  = 112.
+  top: convert.rem(112px);
 }
 
 .sticky-container-hidden {

--- a/services/web-app/components/typeset-style/typeset-style.module.scss
+++ b/services/web-app/components/typeset-style/typeset-style.module.scss
@@ -318,6 +318,7 @@
   position: sticky;
   z-index: 5;
   top: 0;
+  margin-top: spacing.$spacing-09;
   margin-right: -(spacing.$spacing-03);
   margin-left: -(spacing.$spacing-03);
   transition-duration: motion.$transition-expansion;
@@ -331,7 +332,7 @@
 }
 
 .sticky-container-visible {
-  top: 4rem;
+  top: 7rem;
 }
 
 .sticky-container-hidden {


### PR DESCRIPTION
Closes #760
Closes #761



#### Changelog

Fix sticky positioning to allow for sticky tabs. 

#### Testing / reviewing

http://localhost:3000/assets/guidelines/color/usage
http://localhost:3000/assets/guidelines/typography/type-sets
