### PR TITLE
feat: add library asset description

### DIFF
--- a/services/web-app/pages/assets/[host]/[org]/[repo]/[library]/[ref]/index.js
+++ b/services/web-app/pages/assets/[host]/[org]/[repo]/[library]/[ref]/index.js
@@ -76,6 +76,9 @@ const Library = ({ libraryData, params }) => {
         <Column sm={4} md={8} lg={12}>
           <PageHeader title={seo.title} />
         </Column>
+        <Column sm={4} md={8}>
+          <p className={styles.description}>{seo.description}</p>
+        </Column>
         <Column sm={4} md={8} lg={12}>
           <Dashboard className={styles.dashboard}>
             <Column className={dashboardStyles.column} sm={4}>

--- a/services/web-app/pages/assets/[host]/[org]/[repo]/[library]/[ref]/index.js
+++ b/services/web-app/pages/assets/[host]/[org]/[repo]/[library]/[ref]/index.js
@@ -78,7 +78,7 @@ const Library = ({ libraryData, params }) => {
           <PageHeader title={seo.title} />
         </Column>
         <Column sm={4} md={6} lg={8}>
-          <PageDescription className={styles.description}>{seo.description}</PageDescription>
+          <PageDescription>{seo.description}</PageDescription>
         </Column>
         <Column sm={4} md={8} lg={12}>
           <Dashboard className={styles.dashboard}>

--- a/services/web-app/pages/assets/[host]/[org]/[repo]/[library]/[ref]/index.js
+++ b/services/web-app/pages/assets/[host]/[org]/[repo]/[library]/[ref]/index.js
@@ -17,6 +17,7 @@ import { libraryPropTypes, paramsPropTypes } from 'types'
 import { Dashboard, DashboardItem } from '@/components/dashboard'
 import dashboardStyles from '@/components/dashboard/dashboard.module.scss'
 import ExternalLinks from '@/components/external-links'
+import PageDescription from '@/components/page-description'
 import PageHeader from '@/components/page-header'
 import { assetsNavData } from '@/data/nav-data'
 import { teams } from '@/data/teams'
@@ -76,8 +77,8 @@ const Library = ({ libraryData, params }) => {
         <Column sm={4} md={8} lg={12}>
           <PageHeader title={seo.title} />
         </Column>
-        <Column sm={4} md={8}>
-          <p className={styles.description}>{seo.description}</p>
+        <Column sm={4} md={6} lg={8}>
+          <PageDescription className={styles.description}>{seo.description}</PageDescription>
         </Column>
         <Column sm={4} md={8} lg={12}>
           <Dashboard className={styles.dashboard}>

--- a/services/web-app/pages/assets/[host]/[org]/[repo]/[library]/[ref]/index.module.scss
+++ b/services/web-app/pages/assets/[host]/[org]/[repo]/[library]/[ref]/index.module.scss
@@ -7,12 +7,6 @@
 
 @use '@carbon/react/scss/breakpoint' as breakpoint;
 @use '@carbon/react/scss/spacing' as spacing;
-@use '@carbon/react/scss/type' as type;
-
-.description {
-  margin-top: spacing.$spacing-11;
-  @include type.type-style('fluid-heading-03', true);
-}
 
 .dashboard {
   margin-top: spacing.$spacing-11;

--- a/services/web-app/pages/assets/[host]/[org]/[repo]/[library]/[ref]/index.module.scss
+++ b/services/web-app/pages/assets/[host]/[org]/[repo]/[library]/[ref]/index.module.scss
@@ -7,6 +7,12 @@
 
 @use '@carbon/react/scss/breakpoint' as breakpoint;
 @use '@carbon/react/scss/spacing' as spacing;
+@use '@carbon/react/scss/type' as type;
+
+.description {
+  margin-top: spacing.$spacing-11;
+  @include type.type-style('fluid-heading-03', true);
+}
 
 .dashboard {
   margin-top: spacing.$spacing-11;


### PR DESCRIPTION
Closes #558 

Adds the PageDescription component as follows:

breakpoints: `sm={4}` `md={6}` `lg={8}` - like the other carbon pages: https://carbondesignsystem.com/all-about-carbon/what-is-carbon/

<img width="1543" alt="Screen Shot 2022-05-23 at 1 42 53 PM" src="https://user-images.githubusercontent.com/32720851/169885715-4d53c28c-47c9-4de6-9f08-21eebd4db981.png">

Testing: http://localhost:3000/assets/carbon-charts

