### PR TITLE
fix(web-app): top margin library detail page

### DIFF
--- a/services/web-app/pages/assets/[host]/[org]/[repo]/[library]/[ref]/index.js
+++ b/services/web-app/pages/assets/[host]/[org]/[repo]/[library]/[ref]/index.js
@@ -86,7 +86,9 @@ const Library = ({ libraryData, params, navData }) => {
           <PageHeader title={seo.title} />
         </Column>
         <Column sm={4} md={6} lg={8}>
-          <PageDescription>{seo.description}</PageDescription>
+          <PageDescription className={styles['page-description']}>
+            {seo.description}
+          </PageDescription>
         </Column>
         <Column sm={4} md={8} lg={12}>
           <Dashboard className={styles.dashboard}>

--- a/services/web-app/pages/assets/[host]/[org]/[repo]/[library]/[ref]/index.module.scss
+++ b/services/web-app/pages/assets/[host]/[org]/[repo]/[library]/[ref]/index.module.scss
@@ -8,6 +8,10 @@
 @use '@carbon/react/scss/breakpoint' as breakpoint;
 @use '@carbon/react/scss/spacing' as spacing;
 
+.page-description {
+  margin-top: spacing.$spacing-11;
+}
+
 .dashboard {
   margin-top: spacing.$spacing-11;
   margin-bottom: spacing.$spacing-07;


### PR DESCRIPTION
Closes #856

Add correct top margin to library detail page

#### Testing / reviewing

http://localhost:3000/assets/carbon-charts

Margin should be 5rem and match other pages
