### PR TITLE
fix(web-app): asset detail page tab bottom border width

### DIFF
--- a/services/web-app/pages/assets/[host]/[org]/[repo]/[library]/[ref]/[asset].module.scss
+++ b/services/web-app/pages/assets/[host]/[org]/[repo]/[library]/[ref]/[asset].module.scss
@@ -57,22 +57,10 @@
   &::before {
     position: absolute;
     z-index: 0;
-    // manually shift the horizontal line from the tabs to span full width
-    left: -1rem;
     width: 100vw;
     height: convert.rem(48px);
     border-bottom: 1px solid theme.$layer-active-01;
     background: theme.$background;
     content: '';
-    @include breakpoint.breakpoint(md) {
-      left: -2rem;
-    }
-    @include breakpoint.breakpoint(lg) {
-      left: calc(-25vw - 1.5rem);
-    }
-    // 396 = ((1584 / 16) * 4) calc px size of 4 columns at max
-    @include breakpoint.breakpoint(max) {
-      left: calc(-396px - 1.75rem);
-    }
   }
 }


### PR DESCRIPTION
Closes #877


#### Changelog

**Removed**

- unnecessary left value for border

#### Testing / reviewing

Check that tab bottom border displays full width on asset detail page. 

http://localhost:3000/assets/carbon-charts/latest/area-stacked
