### PR TITLE
docs: update usage path docs to allow absolute url

### DIFF
--- a/docs/resource-schemas.md
+++ b/docs/resource-schemas.md
@@ -31,7 +31,7 @@ library:
           path: '/another-page/sub-page.mdx'
           hidden: true
         - title: Another sub page
-          path: '/another-page/another-sub-page.mdx'
+          path: 'https://github.com/carbon-design-system/carbon-website/blob/main/src/pages/developing/react-tutorial/step-1.mdx'
 assets:
   accordion:
     name: Accordion
@@ -118,7 +118,7 @@ library:
           path: '/another-page/sub-page.mdx'
           hidden: true
         - title: Another sub page
-          path: '/another-page/another-sub-page.mdx'
+          path: 'https://github.com/carbon-design-system/carbon-website/blob/main/src/pages/developing/react-tutorial/step-1.mdx'
 ```
 
 ### Library keys
@@ -418,14 +418,14 @@ navData:
         path: '/another-page/sub-page.mdx'
         hidden: true
       - title: Another sub page
-        path: '/another-page/another-sub-page.mdx'
+        path: 'https://github.com/carbon-design-system/carbon-website/blob/main/src/pages/developing/react-tutorial/step-1.mdx'
 ```
 
 For the value of the `navData` array, you can set the following keys.
 
-| Nav data | Description                                                  | Required | Type    | Default |
-| -------- | ------------------------------------------------------------ | -------- | ------- | ------- |
-| `title`  | Navigation title.                                            | Required | String  | –       |
-| `path`   | Path to the file, relative to carbon.yml.                    | Required | String  | –       |
-| `items`  | Second level of navigation.                                  | Optional | Array   | –       |
-| `hidden` | If set to true, the item will be hidden from the navigation. | Optional | Boolean | `false` |
+| Nav data | Description                                                  | Required | Type    | Default | Valid values                                                                                                                                                           |
+| -------- | ------------------------------------------------------------ | -------- | ------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `title`  | Navigation title.                                            | Required | String  | –       | –                                                                                                                                                                      |
+| `path`   | Path to the file.                                            | Required | String  | –       | <ul><li>Github URL according to the `https://{host}/{org}/{repo}/blob/{branch}/{path-to-file}` format </li><li>Path relative to the carbon.yml file location</li></ul> |
+| `items`  | Second level of navigation.                                  | Optional | Array   | –       | –                                                                                                                                                                      |
+| `hidden` | If set to true, the item will be hidden from the navigation. | Optional | Boolean | `false` | –                                                                                                                                                                      |

--- a/packages/schemas/carbon-resources.schema.json
+++ b/packages/schemas/carbon-resources.schema.json
@@ -260,7 +260,7 @@
               },
               "path": {
                 "type": "string",
-                "description": "Path to the file, relative to carbon.yml."
+                "description": "Path to the file, Github URL or path relative to carbon.yml."
               },
               "hidden": {
                 "type": "boolean",
@@ -280,7 +280,7 @@
                     },
                     "path": {
                       "type": "string",
-                      "description": "Path to the file, relative to carbon.yml."
+                      "description": "Path to the file, Github URL or path relative to carbon.yml."
                     },
                     "hidden": {
                       "type": "boolean",

--- a/packages/schemas/internal/validation/library-validation.schema.json
+++ b/packages/schemas/internal/validation/library-validation.schema.json
@@ -77,7 +77,7 @@
           },
           "path": {
             "type": "string",
-            "description": "Path to the file, relative to carbon.yml."
+            "description": "Path to the file, Github URL or path relative to carbon.yml."
           },
           "hidden": {
             "type": "boolean",
@@ -97,7 +97,7 @@
                 },
                 "path": {
                   "type": "string",
-                  "description": "Path to the file, relative to carbon.yml."
+                  "description": "Path to the file, Github URL or path relative to carbon.yml."
                 },
                 "hidden": {
                   "type": "boolean",


### PR DESCRIPTION
Closes #900 
Update library schema docs to allow both relative and absolute urls in `navData`




