### PR TITLE
feat(web-app): functions catalog update

### DIFF
--- a/services/web-app/components/asset-catalog-item/asset-catalog-item.js
+++ b/services/web-app/components/asset-catalog-item/asset-catalog-item.js
@@ -45,7 +45,7 @@ AssetCatalogItemImage.propTypes = {
   asset: assetPropTypes
 }
 
-const AssetCatalogItemContent = ({ asset, isGrid = false, otherFrameworkCount = 0 }) => {
+const AssetCatalogItemContent = ({ asset, isGrid = false, otherFrameworkCount = 0, showImage }) => {
   const isLg = useMatchMedia(mediaQueries.lg)
 
   const { name, description } = asset.content
@@ -61,7 +61,7 @@ const AssetCatalogItemContent = ({ asset, isGrid = false, otherFrameworkCount = 
 
   return (
     <Grid className={styles.content}>
-      <Column sm={4} md={4} lg={7} xlg={6}>
+      <Column sm={4} md={4} lg={7} xlg={6} className={!showImage && styles['no-image']}>
         {asset.library.content.name && (
           <p className={styles.library}>{asset.library.content.name}</p>
         )}
@@ -102,7 +102,8 @@ const AssetCatalogItemContent = ({ asset, isGrid = false, otherFrameworkCount = 
 
 AssetCatalogItemContent.defaultProps = {
   isGrid: false,
-  otherFrameworkCount: 0
+  otherFrameworkCount: 0,
+  showImage: true
 }
 
 AssetCatalogItemContent.propTypes = {
@@ -117,10 +118,14 @@ AssetCatalogItemContent.propTypes = {
   /**
    * Count of other frameworks asset is also available in
    */
-  otherFrameworkCount: PropTypes.number
+  otherFrameworkCount: PropTypes.number,
+  /**
+   * Show image (True) or not (false)
+   */
+  showImage: PropTypes.bool
 }
 
-const AssetCatalogItem = ({ asset, isGrid = false, otherFrameworkCount = 0 }) => {
+const AssetCatalogItem = ({ asset, showImage, isGrid = false, otherFrameworkCount = 0 }) => {
   const isMd = useMatchMedia(mediaQueries.md)
   const isLg = useMatchMedia(mediaQueries.lg)
   const isXlg = useMatchMedia(mediaQueries.xlg)
@@ -141,9 +146,11 @@ const AssetCatalogItem = ({ asset, isGrid = false, otherFrameworkCount = 0 }) =>
     <Column as="li" md={4}>
       <Link href={anchorHref}>
         <a className={anchorStyles}>
-          <AspectRatio ratio="3x2">
-            <AssetCatalogItemImage asset={asset} />
-          </AspectRatio>
+          {showImage && (
+            <AspectRatio ratio="3x2">
+              <AssetCatalogItemImage asset={asset} />
+            </AspectRatio>
+          )}
           <AspectRatio ratio="16x9">
             <AssetCatalogItemContent
               asset={asset}
@@ -161,18 +168,26 @@ const AssetCatalogItem = ({ asset, isGrid = false, otherFrameworkCount = 0 }) =>
       <Link href={anchorHref}>
         <a className={anchorStyles}>
           <Grid narrow>
-            <Column className={clsx(styles.column, styles['column--image'])} md={4}>
-              <AspectRatio ratio={imageAspectRatio()}>
-                <AssetCatalogItemImage asset={asset} />
-              </AspectRatio>
-            </Column>
-            <Column className={clsx(styles.column, styles['column--content'])} sm={4} md={4} lg={8}>
+            {showImage && (
+              <Column className={clsx(styles.column, styles['column--image'])} md={4}>
+                <AspectRatio ratio={imageAspectRatio()}>
+                  <AssetCatalogItemImage asset={asset} />
+                </AspectRatio>
+              </Column>
+            )}
+            <Column
+              className={clsx(styles.column, styles['column--content'])}
+              sm={4}
+              md={showImage ? 4 : 8}
+              lg={showImage ? 8 : 12}
+            >
               {!isMd && (
                 <AspectRatio ratio="3x2">
                   <AssetCatalogItemContent
                     asset={asset}
                     otherFrameworkCount={otherFrameworkCount}
                     isGrid={isGrid}
+                    showImage={showImage}
                   />
                 </AspectRatio>
               )}
@@ -181,6 +196,7 @@ const AssetCatalogItem = ({ asset, isGrid = false, otherFrameworkCount = 0 }) =>
                   asset={asset}
                   otherFrameworkCount={otherFrameworkCount}
                   isGrid={isGrid}
+                  showImage={showImage}
                 />
               )}
             </Column>
@@ -194,6 +210,7 @@ const AssetCatalogItem = ({ asset, isGrid = false, otherFrameworkCount = 0 }) =>
 }
 
 AssetCatalogItem.defaultProps = {
+  showImage: true,
   isGrid: false,
   otherFrameworkCount: 0
 }
@@ -210,7 +227,11 @@ AssetCatalogItem.propTypes = {
   /**
    * Count of other frameworks asset is also available in
    */
-  otherFrameworkCount: PropTypes.number
+  otherFrameworkCount: PropTypes.number,
+  /**
+   * Show image (True) or not (false)
+   */
+  showImage: PropTypes.bool
 }
 
 export default AssetCatalogItem

--- a/services/web-app/components/asset-catalog-item/asset-catalog-item.module.scss
+++ b/services/web-app/components/asset-catalog-item/asset-catalog-item.module.scss
@@ -17,6 +17,7 @@
 
 .column {
   position: relative;
+  min-height: convert.rem(176px);
   transition: border-color motion.$duration-fast-02 motion.motion(standard, productive);
 
   &:not(:first-child) {
@@ -179,12 +180,27 @@
 
 .tags {
   position: absolute;
-  top: spacing.$spacing-04;
-  right: 0;
+  bottom: spacing.$spacing-04;
+  left: 0;
   display: flex;
   transition: background motion.$duration-fast-02 motion.motion(standard, productive);
+
+  .no-image & {
+    @include breakpoint.breakpoint(md) {
+      top: spacing.$spacing-04;
+      right: 0;
+      bottom: auto;
+      left: auto;
+    }
+    @include breakpoint.breakpoint(lg) {
+      right: spacing.$spacing-04;
+    }
+  }
   @include breakpoint.breakpoint(lg) {
+    top: spacing.$spacing-04;
     right: spacing.$spacing-04;
+    bottom: auto;
+    left: auto;
   }
 
   .anchor--grid & {
@@ -206,9 +222,23 @@
   }
 }
 
-.meta {
-  &--absolute {
-    position: absolute;
+.meta--absolute {
+  position: absolute;
+  top: spacing.$spacing-03;
+  right: 0;
+
+  .no-image & {
+    @include breakpoint.breakpoint(md) {
+      top: auto;
+      right: auto;
+      bottom: spacing.$spacing-04;
+      left: spacing.$spacing-04;
+    }
+  }
+
+  @include breakpoint.breakpoint(lg) {
+    top: auto;
+    right: auto;
     bottom: spacing.$spacing-04;
     left: spacing.$spacing-04;
   }

--- a/services/web-app/components/assets-catalog/assets-catalog.js
+++ b/services/web-app/components/assets-catalog/assets-catalog.js
@@ -141,7 +141,7 @@ const filterPropertyHasValidValue = (filter, key, value) => {
   )
 }
 
-const AssetsCatalog = ({ collection, glob = {}, libraries, type }) => {
+const AssetsCatalog = ({ collection, glob = {}, libraries, showImage, type }) => {
   const defaultFilter = {}
 
   const [availableFilters] = useState(getFilters({ collection, type }))
@@ -280,6 +280,7 @@ const AssetsCatalog = ({ collection, glob = {}, libraries, type }) => {
       key={`${index}-${getSlug(asset.content)}`}
       isGrid={isGrid}
       otherFrameworkCount={getAssetOtherFrameworkCount(asset)}
+      showImage={showImage}
     />
   )
 
@@ -294,6 +295,7 @@ const AssetsCatalog = ({ collection, glob = {}, libraries, type }) => {
       onFilter={filterAssets}
       onUpdateFilter={updateFilter}
       sortOptions={sortItems}
+      allowMultiView={showImage}
     />
   )
 }
@@ -301,7 +303,8 @@ const AssetsCatalog = ({ collection, glob = {}, libraries, type }) => {
 export default AssetsCatalog
 
 AssetsCatalog.defaultProps = {
-  glob: {}
+  glob: {},
+  showImage: true
 }
 
 AssetsCatalog.propTypes = {
@@ -317,6 +320,10 @@ AssetsCatalog.propTypes = {
    * Libraries array.
    */
   libraries: PropTypes.arrayOf(libraryPropTypes).isRequired,
+  /**
+   * Show image (True) or not (false)
+   */
+  showImage: PropTypes.bool,
   /**
    * type of catalog element.
    */

--- a/services/web-app/pages/assets/functions.js
+++ b/services/web-app/pages/assets/functions.js
@@ -33,8 +33,7 @@ const Functions = ({ librariesData }) => {
     <>
       <NextSeo {...seo} />
       <PageHeader bgColor={func.bgColor} title={seo.title} pictogram={func.icon} />
-      {/* this probably eventually gets replaced  by a functionsCatalog */}
-      <AssetsCatalog libraries={librariesData.libraries} type="function" />
+      <AssetsCatalog libraries={librariesData.libraries} type="function" showImage={false} />
     </>
   )
 }


### PR DESCRIPTION
Closes #886

Functions catalog updates, default to list view only with no thumbnails.
Updated design tweaks at mobile/tablet for all catalogs.

#### Changelog


**Changed**

- Add showImage prop to AssetsCatalog
- Default to list view if showImage is false
- Alternate styling if no image present at tablet


#### Testing / reviewing

Test Functions and Component catalog matches spec in #886 at all breakpoints
http://localhost:3000/assets/functions
http://localhost:3000/assets/components

|         | Functions           | Components  |
| ------------- |:-------------:|:-----:|
|  Desktop     | ![Screen Shot 2022-06-22 at 2 37 02 PM](https://user-images.githubusercontent.com/2753488/175122078-29bd6689-66ea-4b04-8a74-53240be5975c.png) | ![Screen Shot 2022-06-22 at 2 36 49 PM](https://user-images.githubusercontent.com/2753488/175122793-cd79268f-fd06-480c-ac5c-00374eb78704.png) |
| Tablet      | ![Screen Shot 2022-06-22 at 2 37 23 PM](https://user-images.githubusercontent.com/2753488/175122087-59654500-5951-44f5-9723-18d4319aeb6e.png)      | ![Screen Shot 2022-06-22 at 2 37 36 PM](https://user-images.githubusercontent.com/2753488/175122611-7113161b-3db9-40e2-bf39-5a31db64262b.png) |
| Mobile | ![Screen Shot 2022-06-22 at 2 38 02 PM](https://user-images.githubusercontent.com/2753488/175122097-aaa32e36-120d-45fa-8dac-87d5c9bfa9ca.png)     |    ![Screen Shot 2022-06-22 at 2 37 50 PM](https://user-images.githubusercontent.com/2753488/175122560-8dbff213-9fcf-46d2-b3b5-be70f23c3ce4.png) |










