### PR TITLE
fix(web-app): set correct classname for pictogram grid

### DIFF
--- a/services/web-app/components/svg-libraries/pictogram-library/pictogram-category.js
+++ b/services/web-app/components/svg-libraries/pictogram-library/pictogram-category.js
@@ -19,7 +19,7 @@ const PictogramCategory = ({ category, pictograms, columnCount }) => {
   return (
     <section ref={sectionRef} className={styles['svg-category']}>
       <h2 className={clsx(h2, styles['category-title'])}>{category}</h2>
-      <ul className={clsx(styles['svg-grid'], styles['pictogram-list'])}>
+      <ul className={clsx(styles['svg-grid'], styles.pictograms)}>
         {pictograms
           .filter((pictogram) => {
             return !(pictogram.name === 'ibm--z' || pictogram.name === 'ibm--z--partition')


### PR DESCRIPTION
Closes #924 


#### Changelog


**Changed**

- Added correct classname to pictogram library, should now pull in styles to display as 4 column at large+ breakpoint

#### Testing / reviewing

Make sure Pictogram grid is 4 across at large+
http://localhost:3000/elements/pictograms/library
