### PR TITLE
fix(web-app): hide hamburger menu icon on asset detail page

### DIFF
--- a/services/web-app/layouts/layout/layout.js
+++ b/services/web-app/layouts/layout/layout.js
@@ -166,11 +166,13 @@ const Layout = ({ children }) => {
           <Theme theme="g100">
             <Header aria-label="Carbon Design System" className={styles.header}>
               <SkipToContent />
-              <HeaderMenuButton
-                aria-label="Open menu"
-                onClick={onClickSideNavExpand}
-                isActive={isSideNavExpanded}
-              />
+              {showSideNav && (
+                <HeaderMenuButton
+                  aria-label="Open menu"
+                  onClick={onClickSideNavExpand}
+                  isActive={isSideNavExpanded}
+                />
+              )}
               <div className={styles['header-name']}>
                 <Link href="/">
                   <a className="cds--header__name">Carbon Design System</a>


### PR DESCRIPTION
Closes #679



#### Changelog

**New**

- Hide menu button on tablet/mobile if there is no sidenav (asset detail page)

#### Testing / reviewing

Make sure hamburger menu still shows up on other pages.

Should be hidden here http://localhost:3000/libraries/carbon-charts/latest/assets/bar-grouped
