### PR TITLE
fix(web-app): remove ghost Codepen icons import

### DIFF
--- a/services/web-app/components/mdx-icon/mdx-icon.js
+++ b/services/web-app/components/mdx-icon/mdx-icon.js
@@ -6,7 +6,6 @@
  */
 import { Bee, LogoGithub } from '@carbon/icons-react'
 import {
-  Codepen,
   Codesandbox,
   Figma,
   Illustrator,
@@ -36,7 +35,6 @@ const svgIcons = {
   sketch: Sketch,
   codesandbox: Codesandbox,
   illustrator: Illustrator,
-  codepen: Codepen,
   storybook: Storybook,
   medium: Medium,
   npm: Svg32Npm,


### PR DESCRIPTION
Closes #868 

#### Changelog

**Removed**

- Incorrect Codepen import

#### Testing / reviewing

- Nothing should've changed visually
- from `services/web-app` run `npm run build` and compare output against https://github.com/carbon-design-system/carbon-platform/runs/7246434865?check_suite_focus=true;  Verify lines 273,280 of step "Build, Push 🚀 " 
<img width="944" alt="image" src="https://user-images.githubusercontent.com/40550942/178014406-bc8a734b-d0e3-4f8d-8657-77d9a9b06f4f.png">

