### PR TITLE
fix(web-app): allow  popover scrolling on mobile

### DIFF
--- a/services/web-app/components/catalog-multislect-filter/catalog-multiselect-filter.module.scss
+++ b/services/web-app/components/catalog-multislect-filter/catalog-multiselect-filter.module.scss
@@ -102,7 +102,11 @@
 .content {
   width: calc(100vw - var(--scrollbar-width));
   max-width: none;
+  max-height: 100vh;
+  overflow-y: auto;
+
   @include breakpoint.breakpoint(md) {
+    overflow: hidden;
     // span two columns, where each column has a 1px gutter
     width: calc(200% + convert.rem(2px));
   }


### PR DESCRIPTION
Closes #462



#### Changelog



**Changed**

- Add max height to popover and set overflow



#### Testing / reviewing

Ensure popover scrolling works on mobile, and other breakpoints are unchanged
http://localhost:3000/catalogs/components
