### PR TITLE
fix(web-app): // build warning

### DIFF
--- a/services/web-app/components/mdx-wrapper/mdx-wrapper.js
+++ b/services/web-app/components/mdx-wrapper/mdx-wrapper.js
@@ -47,9 +47,10 @@ const MdxWrapper = ({ children, ...props }) => {
         <PageTabs
           title={title}
           tabs={tabs.map((tab) => {
+            const tabSlug = slugify(tab, { strict: true, lower: true })
             return {
               name: tab,
-              path: `/${baseSegment}/${slugify(tab, { strict: true, lower: true })}`
+              path: baseSegment ? `/${baseSegment}/${tabSlug}` : `/${tabSlug}`
             }
           })}
         />


### PR DESCRIPTION
Closes #871 

#### Changelog

**Changed**

- services/web-app/components/mdx-wrapper/mdx-wrapper.js : do not append baseSegment to tab route if empty

#### Testing / reviewing

- Nothing should've changed visually
- from `services/web-app` run `npm run build` and compare output against https://github.com/carbon-design-system/carbon-platform/runs/7246434865?check_suite_focus=true;  Verify lines 289-290,294-295 of step "Build, Push 🚀 "  are not present in local build
<img width="953" alt="image" src="https://user-images.githubusercontent.com/40550942/179061202-1f70b66c-c560-456c-831e-a7b23c6c33ce.png">
