### PR TITLE
fix(web-app): display design only tag in library assets

### DIFF
--- a/services/web-app/data/type.js
+++ b/services/web-app/data/type.js
@@ -51,7 +51,7 @@ export const type = {
   },
   'design-only': {
     bgColor: gray[20],
-    name: 'Design Only',
+    name: 'Design only',
     path: '/',
     textColor: gray[70]
   },

--- a/services/web-app/pages/libraries/[host]/[org]/[repo]/[library]/[ref]/assets/index.js
+++ b/services/web-app/pages/libraries/[host]/[org]/[repo]/[library]/[ref]/assets/index.js
@@ -29,7 +29,6 @@ import { libraryPropTypes, paramsPropTypes, secondaryNavDataPropTypes } from 'ty
 import AssetCatalogItemMeta from '@/components/asset-catalog-item/asset-catalog-item-meta'
 import PageHeader from '@/components/page-header'
 import TypeTag from '@/components/type-tag'
-import { framework } from '@/data/framework'
 import { assetsNavData } from '@/data/nav-data'
 import { ALPHABETICAL_ORDER, sortItems } from '@/data/sort'
 import { LayoutContext } from '@/layouts/layout'
@@ -127,7 +126,7 @@ const LibrayAssets = ({ libraryData, params, navData }) => {
           </Link>
         )
       }
-      if (asset.content.framework === framework['design-only']) {
+      if (asset.content.framework === 'design-only') {
         assetRow.type = (
           <div style={{ display: 'flex' }}>
             <TypeTag type={asset.content.type} className={styles.tag} />


### PR DESCRIPTION
Fixes logical error on library assets page that prevented Design only tag from showing up 


#### Changelog

**Changed**

- services/web-app/pages/libraries/[host]/[org]/[repo]/[library]/[ref]/assets/index.js: fix if statement condition


#### Testing / reviewing

http://localhost:3000/libraries/carbon-charts/latest/assets: validate design tags
<img width="977" alt="image" src="https://user-images.githubusercontent.com/40550942/180318749-d2a4e0e5-803c-46ac-a676-d05c42b47617.png">

