### PR TITLE
fix(web-app): next config output standalone experimental fix

### DIFF
--- a/services/web-app/next.config.mjs
+++ b/services/web-app/next.config.mjs
@@ -33,10 +33,10 @@ const nextConfig = withMDX(
   withYaml({
     pageExtensions: ['js', 'jsx', 'md', 'mdx'],
     experimental: {
-      outputStandalone: true,
       // this includes files from the monorepo base two directories up
       outputFileTracingRoot: path.join(__dirname, '..', '..')
     },
+    output: 'standalone',
     i18n: {
       locales: ['en-US'],
       defaultLocale: 'en-US'


### PR DESCRIPTION
Output standalone is no longer experimental, see:
https://nextjs.org/docs/advanced-features/output-file-tracing#automatically-copying-traced-files

Fixes: 
<img width="1048" alt="image" src="https://user-images.githubusercontent.com/40550942/181028736-1fdfaec1-a668-45aa-afe1-f8a725150754.png">


#### Changelog

**Changed**

- next.config.mjs

