### PR TITLE
fix(web-app): make library name clickable

### DIFF
--- a/services/web-app/pages/libraries/[host]/[org]/[repo]/[library]/[ref]/assets/[asset]/index.js
+++ b/services/web-app/pages/libraries/[host]/[org]/[repo]/[library]/[ref]/assets/[asset]/index.js
@@ -169,13 +169,16 @@ const Asset = ({ libraryData, params }) => {
                 <DashboardItem aspectRatio={{ sm: '2x1', md: '1x1', lg: '3x4', xlg: '1x1' }}>
                   <dl>
                     <dt className={dashboardStyles.label}>Library</dt>
-                    <dd className={dashboardStyles['label--large']}>{libraryData.content.name}</dd>
+                    <dd className={dashboardStyles['label--large']}>
+                      <Link href={libraryPath} passHref>
+                        <CarbonLink className={dashboardStyles['meta-link--large']}>
+                          {libraryData.content.name}
+                          <br />
+                          {`v${libraryData.content.version}`}
+                        </CarbonLink>
+                      </Link>
+                    </dd>
                   </dl>
-                  <Link href={libraryPath} passHref>
-                    <CarbonLink className={dashboardStyles['meta-link--large']}>
-                      {`v${libraryData.content.version}`}
-                    </CarbonLink>
-                  </Link>
                   {MaintainerIcon && (
                     <MaintainerIcon
                       className={clsx(


### PR DESCRIPTION
Closes #1051 



#### Changelog


**Changed**

- Moved library name inside of link



#### Testing / reviewing

Check that library name is clickable on any component detail page 
http://localhost:3000/libraries/ibm-cloud-cognitive/latest/assets/action-bar