### PR TITLE
fix(web-app): remove style overrides content switcher

### DIFF
--- a/services/web-app/components/color-token-table/color-token-table.js
+++ b/services/web-app/components/color-token-table/color-token-table.js
@@ -10,7 +10,8 @@ import {
   Grid,
   OverflowMenu,
   OverflowMenuItem,
-  Switch
+  Switch,
+  Theme
 } from '@carbon/react'
 import clsx from 'clsx'
 import { useCallback, useEffect, useRef, useState } from 'react'
@@ -172,12 +173,14 @@ const ColorTokenTable = () => {
       <Column sm={4} md={8} lg={16}>
         <StickyContainer navBar banner secondary={false}>
           <div ref={containerRef}>
-            <ContentSwitcher className={themeSwitcherClasses} onChange={switchTheme}>
-              <Switch name="white" text={mobile ? 'Wte' : 'White'} />
-              <Switch name="g10" text={mobile ? 'G10' : 'Gray 10'} />
-              <Switch name="g90" text={mobile ? 'G90' : 'Gray 90'} />
-              <Switch name="g100" text={mobile ? 'G100' : 'Gray 100'} />
-            </ContentSwitcher>
+            <Theme theme={'white'}>
+              <ContentSwitcher size="lg" className={themeSwitcherClasses} onChange={switchTheme}>
+                <Switch name="white" text={mobile ? 'Wte' : 'White'} />
+                <Switch name="g10" text={mobile ? 'G10' : 'Gray 10'} />
+                <Switch name="g90" text={mobile ? 'G90' : 'Gray 90'} />
+                <Switch name="g100" text={mobile ? 'G100' : 'Gray 100'} />
+              </ContentSwitcher>
+            </Theme>
           </div>
         </StickyContainer>
 

--- a/services/web-app/components/color-token-table/color-token-table.module.scss
+++ b/services/web-app/components/color-token-table/color-token-table.module.scss
@@ -20,18 +20,7 @@
 }
 
 .theme-switcher {
-  position: relative;
-  width: 100%;
-  height: 3rem;
-  background: theme.$layer-01;
-
-  @include breakpoint.breakpoint-down('lg') {
-    margin-left: 0;
-  }
-  @include breakpoint.breakpoint-down('md') {
-    max-width: calc(100% - 1rem);
-    margin-left: spacing.$spacing-03;
-  }
+  background: theme.$background;
 }
 
 .theme-switcher::before {
@@ -40,8 +29,8 @@
   left: 0;
   display: block;
   width: 100%;
-  height: convert.rem(64px);
-  background: theme.$background;
+  height: 1rem;
+  background: theme.$layer-01;
   content: '';
 }
 
@@ -101,33 +90,7 @@
 
 /* override carbon content switcher styles */
 .theme-switcher :global(.cds--content-switcher-btn) {
-  height: 3rem;
-  flex: 1;
-  padding: spacing.$spacing-03 spacing.$spacing-07 spacing.$spacing-03 spacing.$spacing-05;
   border-radius: 0;
-
-  @include breakpoint.breakpoint('sm') {
-    padding-right: spacing.$spacing-05;
-  }
-
-  @include breakpoint.breakpoint('md') {
-    padding-right: spacing.$spacing-10;
-  }
-}
-
-.theme-switcher :global(.cds--content-switcher-btn:not(.cds--content-switcher--selected)) {
-  background-color: theme.$layer-01;
-  color: theme.$text-primary;
-
-  &:hover {
-    background-color: theme.$background-hover;
-  }
-}
-
-.theme-switcher :global(.cds--content-switcher-btn:not(:last-of-type))::after {
-  top: spacing.$spacing-04;
-  right: convert.rem(-1px);
-  height: convert.rem(24px);
 }
 
 .color-token-table table {


### PR DESCRIPTION
Closes #765



#### Changelog


**Removed**

- most of the style overrides for content switcher (except border radius)
- 
#### Testing / reviewing

Check that animation matches core Carbon https://react.carbondesignsystem.com/?path=/story/components-contentswitcher--playground&args=size:lg

http://localhost:3000/elements/color/usage
