### PR TITLE
feat(web-app): add anchor links to library detail page

### DIFF
--- a/services/web-app/pages/libraries/[host]/[org]/[repo]/[library]/[ref]/index.js
+++ b/services/web-app/pages/libraries/[host]/[org]/[repo]/[library]/[ref]/index.js
@@ -15,6 +15,7 @@ import { NextSeo } from 'next-seo'
 import { useContext, useEffect } from 'react'
 import { libraryPropTypes, paramsPropTypes, secondaryNavDataPropTypes } from 'types'
 
+import { AnchorLink, AnchorLinks } from '@/components/anchor-links'
 import CardGroup from '@/components/card-group'
 import { Dashboard, DashboardItem } from '@/components/dashboard'
 import dashboardStyles from '@/components/dashboard/dashboard.module.scss'
@@ -126,77 +127,84 @@ const Library = ({ libraryData, params, navData }) => {
           <PageDescription className={styles['page-description']}>
             {seo.description}
           </PageDescription>
+          <AnchorLinks>
+            <AnchorLink>Dashboard</AnchorLink>
+            {libraryData.content.demoLinks && <AnchorLink>Demo links</AnchorLink>}
+            <AnchorLink>Resources</AnchorLink>
+          </AnchorLinks>
         </Column>
         <Column sm={4} md={8} lg={12}>
-          <Dashboard className={styles.dashboard}>
-            <Column className={dashboardStyles.column} sm={4}>
-              <DashboardItem aspectRatio={{ sm: '2x1', md: '1x1', lg: '3x4', xlg: '1x1' }}>
-                <dl>
-                  <dt className={dashboardStyles.label}>Version</dt>
-                  <dd className={dashboardStyles['label--large']}>{getVersion()}</dd>
-                </dl>
-                {MaintainerIcon && (
-                  <MaintainerIcon
-                    className={clsx(
-                      dashboardStyles['position-bottom-left'],
-                      styles['maintainer-icon']
-                    )}
-                    size={64}
-                  />
-                )}
-              </DashboardItem>
-            </Column>
-            <Column className={dashboardStyles.column} sm={4} lg={8}>
-              <DashboardItem aspectRatio={{ sm: '3x4', md: '3x4', lg: 'none', xlg: 'none' }}>
-                <Grid as="dl" className={dashboardStyles.subgrid}>
-                  <Column className={dashboardStyles.subcolumn} sm={2} lg={4}>
-                    <dt className={dashboardStyles.label}>Maintainer</dt>
-                    <dd className={dashboardStyles.meta}>
-                      {get(teams, `[${libraryData.params.maintainer}].name`, 'Community')}
-                    </dd>
-                  </Column>
-                  <Column className={dashboardStyles.subcolumn} sm={2} lg={4}>
-                    <dt className={dashboardStyles.label}>License</dt>
-                    <dd className={dashboardStyles.meta}>{getLicense(libraryData)}</dd>
-                  </Column>
-                  <Column className={dashboardStyles.subcolumn} sm={2} lg={4}>
-                    <dt className={dashboardStyles.label}>Related libraries</dt>
-                    <dd className={dashboardStyles.meta}>
-                      {relatedLibraries.length > 0 ? relatedLibrariesLinks : '–'}
-                    </dd>
-                  </Column>
-                  <Column className={dashboardStyles.subcolumn} sm={2} lg={4}>
-                    <dt className={dashboardStyles.label}>Design files</dt>
-                    <dd className={dashboardStyles.meta}>
-                      <Link href={designKitPath} passHref>
-                        <CarbonLink size="lg">View compatible kits</CarbonLink>
-                      </Link>
-                    </dd>
-                  </Column>
-                </Grid>
+          <div id="dashboard">
+            <Dashboard className={styles.dashboard}>
+              <Column className={dashboardStyles.column} sm={4}>
+                <DashboardItem aspectRatio={{ sm: '2x1', md: '1x1', lg: '3x4', xlg: '1x1' }}>
+                  <dl>
+                    <dt className={dashboardStyles.label}>Version</dt>
+                    <dd className={dashboardStyles['label--large']}>{getVersion()}</dd>
+                  </dl>
+                  {MaintainerIcon && (
+                    <MaintainerIcon
+                      className={clsx(
+                        dashboardStyles['position-bottom-left'],
+                        styles['maintainer-icon']
+                      )}
+                      size={64}
+                    />
+                  )}
+                </DashboardItem>
+              </Column>
+              <Column className={dashboardStyles.column} sm={4} lg={8}>
+                <DashboardItem aspectRatio={{ sm: '3x4', md: '3x4', lg: 'none', xlg: 'none' }}>
+                  <Grid as="dl" className={dashboardStyles.subgrid}>
+                    <Column className={dashboardStyles.subcolumn} sm={2} lg={4}>
+                      <dt className={dashboardStyles.label}>Maintainer</dt>
+                      <dd className={dashboardStyles.meta}>
+                        {get(teams, `[${libraryData.params.maintainer}].name`, 'Community')}
+                      </dd>
+                    </Column>
+                    <Column className={dashboardStyles.subcolumn} sm={2} lg={4}>
+                      <dt className={dashboardStyles.label}>License</dt>
+                      <dd className={dashboardStyles.meta}>{getLicense(libraryData)}</dd>
+                    </Column>
+                    <Column className={dashboardStyles.subcolumn} sm={2} lg={4}>
+                      <dt className={dashboardStyles.label}>Related libraries</dt>
+                      <dd className={dashboardStyles.meta}>
+                        {relatedLibraries.length > 0 ? relatedLibrariesLinks : '–'}
+                      </dd>
+                    </Column>
+                    <Column className={dashboardStyles.subcolumn} sm={2} lg={4}>
+                      <dt className={dashboardStyles.label}>Design files</dt>
+                      <dd className={dashboardStyles.meta}>
+                        <Link href={designKitPath} passHref>
+                          <CarbonLink size="lg">View compatible kits</CarbonLink>
+                        </Link>
+                      </dd>
+                    </Column>
+                  </Grid>
 
-                <ButtonSet className={dashboardStyles['button-set']}>
-                  <Button
-                    className={dashboardStyles['dashboard-button']}
-                    onClick={() => {
-                      router.push(assetsPath)
-                    }}
-                  >
-                    View library assets
-                    <ArrowRight size={16} />
-                  </Button>{' '}
-                  <Button
-                    kind="tertiary"
-                    className={dashboardStyles['dashboard-button']}
-                    href={libraryData.content.externalDocsUrl}
-                  >
-                    View library docs
-                    <Launch size={16} />
-                  </Button>
-                </ButtonSet>
-              </DashboardItem>
-            </Column>
-          </Dashboard>
+                  <ButtonSet className={dashboardStyles['button-set']}>
+                    <Button
+                      className={dashboardStyles['dashboard-button']}
+                      onClick={() => {
+                        router.push(assetsPath)
+                      }}
+                    >
+                      View library assets
+                      <ArrowRight size={16} />
+                    </Button>{' '}
+                    <Button
+                      kind="tertiary"
+                      className={dashboardStyles['dashboard-button']}
+                      href={libraryData.content.externalDocsUrl}
+                    >
+                      View library docs
+                      <Launch size={16} />
+                    </Button>
+                  </ButtonSet>
+                </DashboardItem>
+              </Column>
+            </Dashboard>
+          </div>
         </Column>
         {libraryData.content.demoLinks && (
           <Column sm={4} md={8} lg={8}>


### PR DESCRIPTION
Closes #1038 



#### Changelog

**New**

- Add anchor links to library detail, always show dashboard and resources, only show demo links if there are demo links.


#### Testing / reviewing
Test library with and without demo links

http://localhost:3000/libraries/ibmdotcom-web-components#dashboard
http://localhost:3000/libraries/ibm-cloud-cognitive
