### PR TITLE
fix(web-app): arrow icon color

### DIFF
--- a/services/web-app/pages/libraries/[host]/[org]/[repo]/[library]/[ref]/assets/index.module.scss
+++ b/services/web-app/pages/libraries/[host]/[org]/[repo]/[library]/[ref]/assets/index.module.scss
@@ -126,7 +126,7 @@
   position: absolute;
   top: convert.rem(18px);
   right: convert.rem(20px);
-  color: theme.$interactive;
+  fill: theme.$icon-primary;
 }
 
 .library-assets-container {


### PR DESCRIPTION
Closes #1043 

Update arrow color/fill on asset table. (should not be blue)


#### Testing / reviewing
http://localhost:3000/libraries/carbon-charts/latest/assets
