### PR TITLE
fix: update and use teams data in design kits table

### DIFF
--- a/packages/resources/carbon.yml
+++ b/packages/resources/carbon.yml
@@ -92,28 +92,28 @@ designKits:
     url: https://www.figma.com/file/TckQzGe3bNxHPLoRhbXFal/Gray-100-Theme---Carbon-Design-System
     action: link
   carbon-white-adobe-xd:
-    name: White theme
+    name: Adobe XD white theme
     tool: adobe-xd
     type: ui
     status: stable
     url: https://assets.adobe.com/libraries/urn:aaid:sc:VA7:35c94afd-9cc4-4703-a4b0-49acb165d28d?libraryVersion=8&org=973430F0543801CA0A4C98C6%40AdobeOrg
     action: link
   carbon-g10-adobe-xd:
-    name: Gray 10 theme
+    name: Adobe XD gray 10 theme
     tool: adobe-xd
     type: ui
     status: stable
     url: https://assets.adobe.com/libraries/urn:aaid:sc:VA7:92418e29-f824-4cfc-9be2-866a5230cbb1?libraryVersion=5&org=973430F0543801CA0A4C98C6%40AdobeOrg
     action: link
   carbon-g90-adobe-xd:
-    name: Gray 90 theme
+    name: Adobe XD gray 90 theme
     tool: adobe-xd
     type: ui
     status: stable
     url: https://assets.adobe.com/libraries/urn:aaid:sc:VA7:fc4859fd-beea-4407-b41c-34170a4e8203?libraryVersion=9&org=973430F0543801CA0A4C98C6%40AdobeOrg
     action: link
   carbon-g100-adobe-xd:
-    name: Gray 100 theme
+    name: Adobe XD gray 100 theme
     tool: adobe-xd
     type: ui
     status: stable

--- a/services/web-app/components/filterable-design-kit-table/filterable-design-kit-table.js
+++ b/services/web-app/components/filterable-design-kit-table/filterable-design-kit-table.js
@@ -23,6 +23,7 @@ import PropTypes from 'prop-types'
 import { useCallback, useEffect, useState } from 'react'
 
 import { P } from '@/components/markdown'
+import { teams } from '@/data/teams'
 
 import styles from './filterable-design-kit-table.module.scss'
 
@@ -53,16 +54,6 @@ const toolKeyValueMapper = {
   sketch: 'Sketch',
   axure: 'Axure',
   'adobe-xd': 'Adobe XD'
-}
-
-const sponsors = {
-  carbon: 'Carbon',
-  community: 'Community',
-  'ibm-accessibility': 'IBM Accessibility',
-  'ibm-dotcom': 'Carbon for IBM.com',
-  'ibm-cloud': 'IBM Cloud',
-  'ibm-products': 'IBM Products',
-  'ibm-design-language': 'IBM Design Language'
 }
 
 const captions = {
@@ -185,7 +176,7 @@ const FilterableDesignKitTable = ({ designKitsData, designTools, designKitIds })
             <TableBody>
               {hideRepeatedMaintainer(rows).map((row) => (
                 <TableRow key={row.value}>
-                  <TableCell>{sponsors[row.cells[0].value]}</TableCell>
+                  <TableCell>{teams[row.cells[0].value]?.name}</TableCell>
                   <TableCell>{row.cells[1].value}</TableCell>
                   <TableCell>
                     <Tag type={tagColor[row.cells[2].value]}>

--- a/services/web-app/data/design-kits.js
+++ b/services/web-app/data/design-kits.js
@@ -30,13 +30,13 @@ const designKitAllowList = {
     maintainer: 'carbon'
   },
   'ibm-design-language-sketch': {
-    maintainer: 'ibm-design-language'
+    maintainer: 'ibm-brand'
   },
   'ibm-icons-16-20-sketch': {
-    maintainer: 'ibm-design-language'
+    maintainer: 'ibm-brand'
   },
   'ibm-icons-24-32-sketch': {
-    maintainer: 'ibm-design-language'
+    maintainer: 'ibm-brand'
   },
   'ibm-grid-sketch': {
     maintainer: 'carbon'
@@ -69,14 +69,10 @@ const designKitAllowList = {
     maintainer: 'carbon'
   },
   'ibm-icons-adobe-xd': {
-    maintainer: 'ibm-design-language'
+    maintainer: 'ibm-brand'
   },
-  'carbon-g10-axure': {
-    maintainer: 'community'
-  },
-  'carbon-template-axure': {
-    maintainer: 'community'
-  },
+  'carbon-g10-axure': {},
+  'carbon-template-axure': {},
   'data-viz-sketch': {
     maintainer: 'carbon'
   },
@@ -119,5 +115,14 @@ const designKitAllowList = {
     maintainer: 'ibm-cloud'
   }
 }
+
+/**
+ * Design kits with no maintaining team default to `community`.
+ */
+Object.keys(designKitAllowList).forEach((library) => {
+  if (!designKitAllowList[library].maintainer) {
+    designKitAllowList[library].maintainer = 'community'
+  }
+})
 
 export { designKitAllowList, designKitSources }

--- a/services/web-app/data/teams.js
+++ b/services/web-app/data/teams.js
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 import {
+  AccessibilityAlt,
+  Bee as BeeIcon,
   Carbon,
   CarbonForIbmDotcom,
   CarbonForIbmProduct,
@@ -13,6 +15,7 @@ import {
   IbmSecurity,
   Watson
 } from '@carbon/icons-react'
+import { Advocate, Bee as BeePictogram } from '@carbon/pictograms-react'
 import {
   Svg64Carbon,
   Svg64CarbonForIbmDotcom,
@@ -44,29 +47,39 @@ export const teams = {
     name: 'IBM.com',
     pictogram: Svg64CarbonForIbmDotcom
   },
-  'ibm-cloud': {
-    icon: IbmCloud,
-    name: 'IBM Cloud',
-    pictogram: Svg64Cloud
-  },
-  'ibm-security': {
-    icon: IbmSecurity,
-    name: 'IBM Security',
-    pictogram: Svg64Security
+  'ibm-accessibility': {
+    icon: AccessibilityAlt,
+    name: 'IBM Accessibility',
+    pictogram: Advocate // This is just a placeholder pictogram for now
   },
   'ai-apps': {
     icon: Watson,
     name: 'IBM AI Apps',
     pictogram: Svg64Watson
   },
-  watson: {
-    icon: Watson,
-    name: 'IBM Watson',
-    pictogram: Svg64Watson
+  'ibm-brand': {
+    icon: BeeIcon,
+    name: 'IBM Brand',
+    pictogram: BeePictogram
+  },
+  'ibm-cloud': {
+    icon: IbmCloud,
+    name: 'IBM Cloud',
+    pictogram: Svg64Cloud
   },
   'ibm-products': {
     icon: CarbonForIbmProduct,
     name: 'IBM Products',
     pictogram: Svg64CarbonForIbmProducts
+  },
+  'ibm-security': {
+    icon: IbmSecurity,
+    name: 'IBM Security',
+    pictogram: Svg64Security
+  },
+  watson: {
+    icon: Watson,
+    name: 'IBM Watson',
+    pictogram: Svg64Watson
   }
 }


### PR DESCRIPTION
This PR updates web app teams and the filterable design kit table component that uses those teams.

There will be more team changes in this issue, which is ready for design because we'll need a pictogram for the accessibility team. https://github.com/carbon-design-system/carbon-platform/issues/963

#### Changelog

**New**

- IBM Brand team, with the bee as its icon and pictogram
- IBM Accessibility team, with an accessibility alt icon and a placeholder pictogram

**Changed**

- Reverts the changes to the indexed Adobe XD kit names, because if we change the naming convention for design kits, we should do that for all indexed design kits at once
- `designKitAllowList` now defaults to community maintained, if not specified

**Removed**

- N/A

#### Testing / reviewing

Indexed design kits: https://github.com/carbon-design-system/carbon-platform/blob/6e4dee03e65f45ebfd04fec5ee8e20aa0c850931/packages/resources/carbon.yml

Teams, that are used as design kit maintainers: https://github.com/carbon-design-system/carbon-platform/blob/6e4dee03e65f45ebfd04fec5ee8e20aa0c850931/services/web-app/data/teams.js