### PR TITLE
fix(web-app): update side nav z-index to fix tab bg overlay with scrollbar

### DIFF
--- a/services/web-app/layouts/layout/layout.module.scss
+++ b/services/web-app/layouts/layout/layout.module.scss
@@ -5,14 +5,14 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+@use '../../styles/variables' as variables;
+@use 'sass:map';
 @use '@carbon/react/scss/breakpoint' as breakpoint;
 @use '@carbon/react/scss/spacing' as spacing;
 @use '@carbon/react/scss/theme' as theme;
 @use '@carbon/react/scss/motion' as motion;
 @use '@carbon/react/scss/type' as type;
 @use '@carbon/react/scss/utilities/convert' as convert;
-@use '../../styles/variables' as variables;
-@use 'sass:map';
 
 .body {
   flex-grow: 1;

--- a/services/web-app/layouts/layout/layout.module.scss
+++ b/services/web-app/layouts/layout/layout.module.scss
@@ -11,6 +11,8 @@
 @use '@carbon/react/scss/motion' as motion;
 @use '@carbon/react/scss/type' as type;
 @use '@carbon/react/scss/utilities/convert' as convert;
+@use '../../styles/variables' as variables;
+@use 'sass:map';
 
 .body {
   flex-grow: 1;
@@ -67,7 +69,7 @@
 .side-nav {
   @include breakpoint.breakpoint(lg) {
     position: fixed;
-    z-index: 3;
+    z-index: map.get(variables.$z-indexes, 'overlay');
     top: 0;
     left: 0;
     width: 16rem;


### PR DESCRIPTION
Closes #1078


#### Changelog

**Changed**

- update side nav z-index so it sits above page tabs


#### Testing / reviewing

http://localhost:3000/guidelines/accessibility/overview

Test with scrollbars on and off and make sure pages with tabs render correctly
![Screen Shot 2022-08-16 at 4 23 07 PM](https://user-images.githubusercontent.com/2753488/184987655-20f969b0-04e9-4173-9394-57680b9e68b0.png)

