### PR TITLE
fix(docs): add contributing file to docs website

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,1 +1,2 @@
 remote_theme: pmarsceill/just-the-docs
+include: ['CONTRIBUTING.md']


### PR DESCRIPTION
This should hopefully allow our contributing.md file to be displayed in the dev docs site