### PR TITLE
fix(web-app): resource-card default theme color

### DIFF
--- a/services/web-app/components/resource-card/resource-card.js
+++ b/services/web-app/components/resource-card/resource-card.js
@@ -89,7 +89,7 @@ const ResourceCard = (props) => {
   }
 
   return (
-    <Theme theme={color === 'dark' && 'g100'}>
+    <Theme theme={color === 'dark' ? 'g100' : 'g10'}>
       <div className={ResourceCardClassNames}>
         <AspectRatio ratio={`${aspectRatio.replace(':', 'x')}`}>
           <div className="cds--aspect-ratio--object">{cardContainer}</div>


### PR DESCRIPTION
Fixes the warning being output in the web-app when using the resource-card without specifying `color: 'dark'` as a prop. The default color will be 'light' and will use the g10 theme.