### PR TITLE
fix: rewrite FAQ page

### DIFF
--- a/services/web-app/pages/about-carbon/faq/index.mdx
+++ b/services/web-app/pages/about-carbon/faq/index.mdx
@@ -48,14 +48,15 @@ design patterns across the company.
 
 ### Where do I start if I’m a developer?
 
-Head [here](/developing) to learn about libraries and access everything you need to get up and
-running with your preferred framework — React, Angular, Web Components, Vue, or Svelte.
+Explore the [developer getting started guide](/developing) to learn about libraries and access
+everything you need to get up and running with your preferred framework — React, Angular, Web
+Components, Vue, or Svelte.
 
 ### Where do I start if I’m a designer?
 
-Head [here](/designing/get-started) to learn how design kits are used to build consistent, scalable
-user interfaces — and get started with your design tool of choice, including Figma, Sketch, Adobe
-XD, or Axure.
+Check out the [designer getting started guide](/designing/get-started) to learn how design kits are
+used to build consistent, scalable user interfaces — and get started with your design tool of
+choice, including Figma, Sketch, Adobe XD, or Axure.
 
 ### Which assets can I use?
 

--- a/services/web-app/pages/about-carbon/faq/index.mdx
+++ b/services/web-app/pages/about-carbon/faq/index.mdx
@@ -1,7 +1,11 @@
 ---
 title: FAQs
-description: Below are frequently asked questions about the Carbon Design System.
+description: This page answers frequently asked questions about the Carbon Design System.
 ---
+
+<PageDescription>
+  Below are frequently asked questions about the Carbon Design System.
+</PageDescription>
 
 <AnchorLinks>
 
@@ -68,8 +72,8 @@ Carbon has to offer, with filters to find exactly what you need.
 ### Where can I find documentation for earlier versions of Carbon?
 
 You can find earlier versions of Carbon documentation here:
-**[V6](http://v6.carbondesignsystem.com/)**, **[V7](http://v7.carbondesignsystem.com/)**,
-**[V8](http://v8.carbondesignsystem.com/)**, **[V9](http://v9.carbondesignsystem.com/)**, and
+**[V6](https://v6.carbondesignsystem.com/)**, **[V7](https://v7.carbondesignsystem.com/)**,
+**[V8](https://v8.carbondesignsystem.com/)**, **[V9](https://v9.carbondesignsystem.com/)**, and
 **[V10](https://v10.carbondesignsystem.com/)**. Browser support is on a per-library basis and Carbon
 V11 does not support Internet Explorer 11.
 
@@ -96,8 +100,8 @@ reader or other assistive technology.
 
 ### What should I do if I find a component that isn’t accessible?
 
-First, refer to the [accessibility guidelines](/elements/accessibility/overview) to confirm that the
-component fails accessibility standards. If confirmed,
+First, refer to the [accessibility guidelines](/guidelines/accessibility/overview) to confirm that
+the component fails accessibility standards. If confirmed,
 [create a GitHub issue](https://github.com/carbon-design-system/carbon/issues/new/choose) in the
 Components repo and describe the steps to reproduce the problem. If the asset maintainer confirms
 the problem, they will work to fix it as quickly as possible.

--- a/services/web-app/pages/about-carbon/faq/index.mdx
+++ b/services/web-app/pages/about-carbon/faq/index.mdx
@@ -1,15 +1,13 @@
 ---
 title: FAQs
-description:
-  What is the Carbon Design System? Who works on Carbon? How can I contribute? Here, we answer some
-  of our frequently asked questions.
+description: Below are frequently asked questions about the Carbon Design System.
 ---
 
 <AnchorLinks>
 
 <AnchorLink>About Carbon</AnchorLink>
-<AnchorLink>Contributing</AnchorLink>
 <AnchorLink>Creating with Carbon</AnchorLink>
+<AnchorLink>Accessibility</AnchorLink>
 <AnchorLink>Telemetry</AnchorLink>
 
 </AnchorLinks>
@@ -18,110 +16,100 @@ description:
 
 ### What is the Carbon Design System?
 
-Carbon is the open-source design system for all IBM software products. It is a series of individual
-styles, components, and guidelines used for creating unified product experiences.
+Carbon is IBM’s design system for products and digital experiences. With the IBM Design Language as
+its foundation, the system consists of working code, design tools and resources, human interface
+guidelines, and a vibrant community of contributors.
 
-To learn more about how we work check out [What is Carbon](/all-about-carbon/what-is-carbon).
+To learn more about the Carbon ecosystem, check out
+[how Carbon works](/about-carbon/how-carbon-works).
 
-### Who works on Carbon?
+### What is Carbon Next?
 
-Carbon has a core team of designers and front-end developers dedicated to developing and supporting
-the system. There are also countless other designers and developers who contribute back to
-[carbon-components](https://github.com/carbon-design-system/carbon-components#contributors) and
-[carbon-react](https://github.com/carbon-design-system/carbon#contributors).
+Carbon Next is a project to create a new version of the Carbon website, as well as new
+infrastructure to support indexing and maintaining assets. This will eventually replace the existing
+Carbon and PAL websites.
 
-## Contributing
+Check out the [platform roadmap](/about-carbon/platform-roadmap) to learn more about planned
+releases.
 
-### How can I contribute and/or propose new components or ideas?
+### Why is the Carbon website changing?
 
-Check out our [contribution overview](/contributing/overview) to learn all about the different ways
-to contribute. Thanks for the help!
-
-### I see a bug. How do I report it?
-
-First, make sure the problem is reproducible. Once confirmed, open an issue in the appropriate
-GitHub repo from the following list. We will address the bug as soon as we can. If you have a fix
-for the bug, please feel free to submit a PR for it.
-
-For larger changes, please see our [contribution overview](/contributing/overview).
-
-#### Design issue repos
-
-- [Design kit](https://github.com/carbon-design-system/carbon-design-kit/issues/new)
-- [Icons](https://github.com/carbon-design-system/carbon-icons/issues/new)
-- [Website](https://github.com/carbon-design-system/carbon-website/issues/new/choose)
-- [Components](https://github.com/carbon-design-system/carbon/issues/new/choose)
-- [Elements](https://github.com/carbon-design-system/carbon/issues/new/choose)
-- [Charts](https://github.com/carbon-design-system/carbon-charts/issues/new)
-- [Everything else](https://github.com/carbon-design-system/issue-tracking/issues/new)
-
-#### Code repos
-
-- [@carbon/react](https://github.com/carbon-design-system/carbon/issues/new/choose)
-- [carbon-components-angular](https://github.com/IBM/carbon-components-angular/issues/new)
-- [carbon-components-vanilla](https://github.com/carbon-design-system/carbon/issues/new/choose)
-- [carbon-components-vue](https://github.com/carbon-design-system/carbon-components-vue/issues/new)
-- [carbon-charts](https://github.com/carbon-design-system/carbon-charts/issues/new)
-
-### What can I expect for a response to my bug report?
-
-If you have a pressing bug or change it is best to make PR for the issue yourself. Our team works in
-sprints and will try to address your bug as soon as possible; sometimes within two or three days,
-but usually by the following sprint. Issues that are out of scope will be closed until they become a
-higher priority.
-
-Typical responses to bug reports will include:
-
-- Need more info, can't reproduce the problem
-- Won't fix, this isn't something we intend to support
-- Confirmed, will add to our roadmap (Carbon team will fix)
-- Confirmed, will accept PRs (need external member to fix)
-- Need to include design to verify this behavior is supported
-
-### What should I do if I find a component that isn't accessible?
-
-First, refer to the [Carbon accessibility guidelines](/elements/accessibility/overview) to confirm
-that the component fails accessibility standards. If confirmed,
-[create a GitHub issue](https://github.com/carbon-design-system/carbon/issues/new/choose) in the
-Components repo and describe the steps to reproduce the problem. If the core Carbon team confirms
-the problem, we will work to fix it as quickly as possible.
+In the past, open and inner source assets were scattered across multiple websites. The new site
+provides a unified discovery experience, which helps designers and developers find and access
+components, patterns, functions and templates across all IBM teams. This will help everyone find
+assets that comply with platform requirements, are convenient to implement, and are consistent with
+design patterns across the company.
 
 ## Creating with Carbon
 
-### Which browsers are supported?
+### Where do I start if I’m a developer?
 
-Carbon components are supported in the following browsers:
+Head [here](/developing) to learn about libraries and access everything you need to get up and
+running with your preferred framework — React, Angular, Web Components, Vue, or Svelte.
 
-- Microsoft Edge latest
-- Firefox latest
-- Chrome latest
-- Safari latest
+### Where do I start if I’m a designer?
 
-### What languages are the components written in?
+Head [here](/designing/get-started) to learn how design kits are used to build consistent, scalable
+user interfaces — and get started with your design tool of choice, including Figma, Sketch, Adobe
+XD, or Axure.
 
-Carbon is built React first. We also support vanilla JS, Angular, Vue, and Svelte implementations.
-Check out [Developing](/developing/) to learn more about what you need to get started with Carbon
-implementations.
+### Which assets can I use?
 
-### Where do I find charts and Data visualization?
+Anyone can use the core system, which includes elements, assets, code, design kits, and guidelines
+intended as a base for the widest variety of situations. These assets are open source and can be
+easily extended or adapted.
 
-Carbon charts and their corresponding assets and documentation are now in the
-[Data visualization](/data-visualization) section.
+Some local systems are open source while others require IBM employee authentication to view.
+
+Catalogs for [components](/assets/components), [patterns](/assets/patterns),
+[functions](/assets/functions), and [templates](/assets/templates) allow you to explore everything
+Carbon has to offer, with filters to find exactly what you need.
 
 ### Where can I find documentation for earlier versions of Carbon?
 
 You can find earlier versions of Carbon documentation here:
 **[V6](http://v6.carbondesignsystem.com/)**, **[V7](http://v7.carbondesignsystem.com/)**,
-**[V8](http://v8.carbondesignsystem.com/)**, and **[V9](http://v9.carbondesignsystem.com/).**
+**[V8](http://v8.carbondesignsystem.com/)**, **[V9](http://v9.carbondesignsystem.com/)**, and
+**[V10](https://v10.carbondesignsystem.com/)**. Browser support is on a per-library basis and Carbon
+V11 does not support Internet Explorer 11.
+
+### How can I contribute to new components, guidelines, or fixes?
+
+Contributors are members of the community who contribute to Carbon in a material way. Anyone can be
+a contributor. Check out our [contribution overview](/contributing/overview) to learn all about the
+different ways to contribute or
+[create a GitHub issue](https://github.com/carbon-design-system/carbon/issues/new/choose) to report
+something that isn’t working correctly. Thanks for the help!
+
+## Accessibility
+
+### Is the Carbon Design System accessible?
+
+IBM firmly believes that web and software experiences should be accessible for everyone. Carbon is
+committed to following and complying with accessibility best practices.
+
+Carbon components follow the
+[IBM accessibility checklist](https://www.ibm.com/able/requirements/requirements/?_ga=2.226507220.899498654.1661181268-592751643.1649883372)
+which is based on WCAG AA, Section 508, and European standards. The Carbon team strives to write
+perceivable, operable, and understandable patterns for all users—including those employing a screen
+reader or other assistive technology.
+
+### What should I do if I find a component that isn’t accessible?
+
+First, refer to the [accessibility guidelines](/elements/accessibility/overview) to confirm that the
+component fails accessibility standards. If confirmed,
+[create a GitHub issue](https://github.com/carbon-design-system/carbon/issues/new/choose) in the
+Components repo and describe the steps to reproduce the problem. If the asset maintainer confirms
+the problem, they will work to fix it as quickly as possible.
 
 ## Telemetry
 
-Carbon contains a telemetry feature that collects usage information for IBM and Carbon Design System
-properties.
+### What is telemetry and why is it useful?
 
-### Why is telemetry collected?
-
-Carbon collects telemetry information to influence Carbon's roadmap and prioritize bug fixes.
+Telemetry is a feature that collects anonymous usage information for IBM and Carbon Design System
+properties. Usage data is used to prioritize updates to the website and is also visible on a
+per-library and per-asset basis on the website to help all maintainers prioritize usage decisions
+for their assets.
 
 ### When is data collected?
 
@@ -148,5 +136,5 @@ The following is collected through a postinstall script:
 
 ### How do I opt out?
 
-Participation in Carbon's telemetry is optional. To opt-out, set the environment variable
+Participation in Carbon’s telemetry is optional. To opt-out, set the environment variable
 `CARBON_TELEMETRY_DISABLED` to `1`.


### PR DESCRIPTION
Closes #781

We originally pulled in the CDS FAQ page, but have now updated the content to better match with the Carbon Next site. 

#### Change log

**Changed**

- [See Figma](https://www.figma.com/file/FpVufniwvHjpMLdnBUshsE/FAQ-Page?node-id=0%3A1) for notes on what was changed.

#### Testing / reviewing

- Read through the page. Is the information provided accurate for V1? (the FAQ will be updated once we have login/teams)
- Check links. Are links within the site formatted correctly?
- This page only contains headers and body text so no need for visual review. 
