### PR TITLE
fix(web-app): build mdx pages dynamically

### DIFF
--- a/services/web-app/pages/[...remote-mdx-path].js
+++ b/services/web-app/pages/[...remote-mdx-path].js
@@ -80,19 +80,9 @@ export const getStaticProps = async ({ params }) => {
 }
 
 export const getStaticPaths = async () => {
-  const allowedPaths = Object.keys(remotePages).map((remotePage) => {
-    return {
-      params: {
-        'remote-mdx-path': remotePage.split('/')
-      }
-    }
-  })
-
   return {
-    paths: allowedPaths,
-    // returning 404 if page wasn't generated at build time
-    // to prevent remote mdx dynamic loading for now
-    fallback: false
+    paths: [],
+    fallback: 'blocking'
   }
 }
 


### PR DESCRIPTION
Closes #944


#### Changelog

**Changed**

- fallback 'blocking' on getStaticPaths to generate page dynamically
- 
#### Testing / reviewing

Test you're still able to render remote pages and lib pages (react tutorial)
