### PR TITLE
feat(web-app): lock down iframe props

### DIFF
--- a/services/web-app/components/preview/preview.js
+++ b/services/web-app/components/preview/preview.js
@@ -5,7 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import Proptypes from 'prop-types'
+import clsx from 'clsx'
+import PropTypes from 'prop-types'
 
 import styles from './preview.module.scss'
 
@@ -13,7 +14,7 @@ import styles from './preview.module.scss'
  * The `<Preview>` component is a simple wrapper for an `<iframe />` with
  * styling added to allow it to display responsively within the Platform.
  */
-const Preview = ({ title, height, src, style }) => (
+const Preview = ({ className, title, height, src, style }) => (
   <iframe
     src={src}
     loading="lazy"
@@ -22,21 +23,37 @@ const Preview = ({ title, height, src, style }) => (
     allowtransparency="true"
     allowFullScreen="true"
     frameBorder="no"
-    className={styles.preview}
+    className={clsx(className, styles.preview)}
     style={style}
     sandbox="allow-forms allow-scripts allow-same-origin"
   />
 )
 
 Preview.propTypes = {
-  /** Provide the height for the iframe */
-  height: Proptypes.string,
-  /** Provide the url for the iframe */
-  src: Proptypes.string,
-  /** Provide custom inline styles for the iframe */
-  style: Proptypes.object,
-  /** Provide the title for the iframe */
-  title: Proptypes.string
+  /**
+   * Specify a custom class
+   */
+  className: PropTypes.string,
+
+  /**
+   * Provide the height for the iframe
+   */
+  height: PropTypes.string,
+
+  /**
+   * Provide the url for the iframe
+   */
+  src: PropTypes.string,
+
+  /**
+   * Provide custom inline styles for the iframe
+   */
+  style: PropTypes.object,
+
+  /**
+   * Provide the title for the iframe
+   */
+  title: PropTypes.string
 }
 
 export default Preview

--- a/services/web-app/components/preview/preview.js
+++ b/services/web-app/components/preview/preview.js
@@ -13,11 +13,28 @@ import styles from './preview.module.scss'
  * The `<Preview>` component is a simple wrapper for an `<iframe />` with
  * styling added to allow it to display responsively within the Platform.
  */
-const Preview = ({ title, ...props }) => (
-  <iframe loading="lazy" title={title} {...props} className={styles.preview} />
+const Preview = ({ title, height, src, style }) => (
+  <iframe
+    src={src}
+    loading="lazy"
+    title={title}
+    height={height}
+    allowtransparency="true"
+    allowFullScreen="true"
+    frameBorder="no"
+    className={styles.preview}
+    style={style}
+    sandbox="allow-forms allow-scripts allow-same-origin"
+  />
 )
 
 Preview.propTypes = {
+  /** Provide the height for the iframe */
+  height: Proptypes.string,
+  /** Provide the url for the iframe */
+  src: Proptypes.string,
+  /** Provide custom inline styles for the iframe */
+  style: Proptypes.object,
   /** Provide the title for the iframe */
   title: Proptypes.string
 }

--- a/services/web-app/components/storybook-demo/storybook-demo.js
+++ b/services/web-app/components/storybook-demo/storybook-demo.js
@@ -115,6 +115,7 @@ const StorybookDemo = ({ tall, themeSelector, wide, url, variants }) => {
             frameBorder="no"
             allowtransparency="true"
             allowFullScreen="true"
+            sandbox="allow-forms allow-scripts allow-same-origin"
           />
         </Column>
       </Grid>

--- a/services/web-app/components/video/video.js
+++ b/services/web-app/components/video/video.js
@@ -49,6 +49,7 @@ const Video = ({ autoPlay, vimeoId, title, src, poster, muted, ...props }) => {
                   webkitallowfullscreen="true"
                   mozallowfullscreen="true"
                   allowFullScreen
+                  sandbox="allow-forms allow-scripts  allow-same-origin"
                 />
               </div>
             </div>


### PR DESCRIPTION
closes #1172

#### Changelog

- Add sandbox prop to all components using iframes. (Video, Preview, StorybookDemo)

**Removed**

- prop spread to iframe inside of Preview component

#### Testing / reviewing

Make sure the following components still render as expected

- Video http://localhost:3000/elements/2x-grid/overview
- Preview http://localhost:3000/mdx/preview
- StorybookDemo http://localhost:3000/mdx/storybook-demo
 