### PR TITLE
fix: mobile text alignment

### DIFF
--- a/services/web-app/components/catalog-sort/catalog-sort.module.scss
+++ b/services/web-app/components/catalog-sort/catalog-sort.module.scss
@@ -57,7 +57,6 @@
   position: relative;
   display: flex;
   width: 100%;
-  padding-left: spacing.$spacing-05;
   grid-gap: 0;
 
   // overide carbon color
@@ -76,6 +75,10 @@
   :global(.cds--list-box__field),
   :global(.cds--list-box__menu) {
     max-width: none;
+  }
+
+  @include breakpoint.breakpoint(md) {
+    padding-left: spacing.$spacing-05;
   }
 }
 


### PR DESCRIPTION
Closes #1186 

Make sure in mobile `Sort by:` text is left aligned

## Testing: 

http://localhost:3000/assets/components
