### PR TITLE
fix: get started spacing bug

### DIFF
--- a/services/web-app/pages/designing/get-started.mdx
+++ b/services/web-app/pages/designing/get-started.mdx
@@ -181,7 +181,8 @@ design kits include elements, core components, wireframes, and guidelines.
 
 ### Local design kits
 
-Additional design kits compliment and extend Carbon. For example, IBM.com provides components for an editorial approach. More kits can be found in the [design kit catalog](). The kits in the table
+Additional design kits compliment and extend Carbon. For example, IBM.com provides components for an
+editorial approach. More kits can be found in the [design kit catalog](). The kits in the table
 below are only offered in Figma.
 
 <FilterableDesignKitTable

--- a/services/web-app/pages/designing/get-started.mdx
+++ b/services/web-app/pages/designing/get-started.mdx
@@ -181,11 +181,7 @@ design kits include elements, core components, wireframes, and guidelines.
 
 ### Local design kits
 
-Additional design kits compliment and extend Carbon. For example, IBM.com provides components for an
-
-{/* TODO: add design kit catalog url */}
-
-editorial approach. More kits can be found in the [design kit catalog](). The kits in the table
+Additional design kits compliment and extend Carbon. For example, IBM.com provides components for an editorial approach. More kits can be found in the [design kit catalog](). The kits in the table
 below are only offered in Figma.
 
 <FilterableDesignKitTable


### PR DESCRIPTION
Closes #1197 

This fixes the spacing issue on the `design / get-started` page - by removing the `TODO` comment - which will now be tracked here: https://github.com/carbon-design-system/carbon-platform/issues/919

## Testing: 

- http://localhost:3000/designing/get-started
