### PR TITLE
fix(web-app): only include related library if not null and with content

### DIFF
--- a/services/web-app/lib/github.js
+++ b/services/web-app/lib/github.js
@@ -487,8 +487,9 @@ export const getLibraryRelatedLibs = async (libData) => {
           ...libraryParams
         })
         if (
-          relatedLibData?.content.id !== libData.content.id &&
-          !relatedLibData?.content?.noIndex
+          relatedLibData?.content &&
+          relatedLibData.content.id !== libData.content.id &&
+          !relatedLibData.content.noIndex
         ) {
           relatedLibs.push(relatedLibData)
         }


### PR DESCRIPTION
Closes #1217 

Issue was happening when data for relatedLibs could not be obtained successfully (item inside `otherLibraries` array was `null` , added condition to only include lib in relatedLibs array if details were successfully retrieved

#### Changelog

**Changed**

- services/web-app/lib/github.js: added condition to skip non-complete libs for `getLibraryRelatedLibs`

#### Testing / reviewing

1 - While on `main`, replace this part in `getLibraryRelatedLibs`
 ```
 const relatedLibData = await getLibraryData({
          library: slug,
          ref: 'latest',
          ...libraryParams
        })
 ``` 
with
```
 const relatedLibData =  null
```
2 - Load http://localhost:3000/libraries/carbon-components-angular, confirm you're able to reproduce the error

3 - Checkout to `1217-web-app-nullpointerexception-in-library-details-on-api-rate-limiting`

4 -  replace this part in `getLibraryRelatedLibs`
 ```
 const relatedLibData = await getLibraryData({
          library: slug,
          ref: 'latest',
          ...libraryParams
        })
 ``` 
with
```
 const relatedLibData =  null
```

5 - Load http://localhost:3000/libraries/carbon-components-angular, confirm you're *no longer* able to reproduce the error
