### PR TITLE
feat: add isr fallbacks

### DIFF
--- a/services/web-app/components/nav-primary/nav-primary.js
+++ b/services/web-app/components/nav-primary/nav-primary.js
@@ -5,8 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { HeaderSideNavItems, SideNav, SideNavItems, SideNavLink } from '@carbon/react'
+import { HeaderSideNavItems, SideNav, SideNavItems, SideNavLink, SkeletonText } from '@carbon/react'
 import clsx from 'clsx'
+import isEmpty from 'lodash/isEmpty'
 import { useRouter } from 'next/router'
 import PropTypes from 'prop-types'
 import { useContext } from 'react'
@@ -21,6 +22,7 @@ const NavPrimary = ({ className, globalItems }) => {
   const router = useRouter()
   const { isSideNavExpanded, primaryNavData, isSecondaryNav, setSideNavExpanded } =
     useContext(LayoutContext)
+  const isLoading = isEmpty(primaryNavData)
 
   return (
     <SideNav
@@ -55,8 +57,12 @@ const NavPrimary = ({ className, globalItems }) => {
             })}
           </HeaderSideNavItems>
         )}
-
-        {primaryNavData && primaryNavData.length > 0 && (
+        {isLoading && (
+          <div className={styles.skeleton}>
+            <SkeletonText paragraph />
+          </div>
+        )}
+        {!isLoading && primaryNavData && primaryNavData.length > 0 && (
           <NavTree items={primaryNavData} label="Main navigation" activeItem={router.asPath} />
         )}
       </SideNavItems>

--- a/services/web-app/components/nav-primary/nav-primary.module.scss
+++ b/services/web-app/components/nav-primary/nav-primary.module.scss
@@ -32,3 +32,7 @@
     outline: none !important;
   }
 }
+
+.skeleton {
+  padding: spacing.$spacing-03 spacing.$spacing-05;
+}

--- a/services/web-app/components/nav-secondary/nav-secondary.js
+++ b/services/web-app/components/nav-secondary/nav-secondary.js
@@ -5,9 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { Button, SideNav } from '@carbon/react'
+import { Button, SideNav, SkeletonText } from '@carbon/react'
 import { ArrowLeft } from '@carbon/react/icons'
 import clsx from 'clsx'
+import isEmpty from 'lodash/isEmpty'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { useContext } from 'react'
@@ -23,6 +24,7 @@ const NavSecondary = ({ className, visible, onSlidePrimary }) => {
   const { isSideNavExpanded, secondaryNavData = {}, setSideNavExpanded } = useContext(LayoutContext)
   const isLg = useMatchMedia(mediaQueries.lg)
 
+  const isLoading = isEmpty(secondaryNavData)
   const { back, headings, items, path } = secondaryNavData
 
   // $duration-moderate-01 = 150ms
@@ -37,14 +39,8 @@ const NavSecondary = ({ className, visible, onSlidePrimary }) => {
 
   if (!isLg && !visible) return null
 
-  return (
-    <SideNav
-      aria-label="Secondary side navigation"
-      expanded={isSideNavExpanded}
-      className={clsx(styles['secondary-nav'], className)}
-      aria-hidden={visible ? 'false' : 'true'}
-      onOverlayClick={() => setSideNavExpanded(false)}
-    >
+  const renderContent = () => (
+    <>
       <Button
         kind="ghost"
         onClick={handleBack}
@@ -74,6 +70,23 @@ const NavSecondary = ({ className, visible, onSlidePrimary }) => {
         </Link>
       )}
       {items && <NavTree items={items} label="Secondary navigation" activeItem={router.asPath} />}
+    </>
+  )
+
+  return (
+    <SideNav
+      aria-label="Secondary side navigation"
+      expanded={isSideNavExpanded}
+      className={clsx(styles['secondary-nav'], className)}
+      aria-hidden={visible ? 'false' : 'true'}
+      onOverlayClick={() => setSideNavExpanded(false)}
+    >
+      {isLoading && (
+        <div className={styles.skeleton}>
+          <SkeletonText paragraph />
+        </div>
+      )}
+      {!isLoading && renderContent()}
     </SideNav>
   )
 }

--- a/services/web-app/components/nav-secondary/nav-secondary.module.scss
+++ b/services/web-app/components/nav-secondary/nav-secondary.module.scss
@@ -116,3 +116,8 @@
 
   display: block;
 }
+
+.skeleton {
+  padding: spacing.$spacing-05;
+  margin: spacing.$spacing-02 0;
+}

--- a/services/web-app/components/page-header/page-header.js
+++ b/services/web-app/components/page-header/page-header.js
@@ -4,12 +4,12 @@
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import { Column, Grid, Theme } from '@carbon/react'
+import { Column, Grid, SkeletonText, Theme } from '@carbon/react'
 import PropTypes from 'prop-types'
 
 import styles from './page-header.module.scss'
 
-const PageHeader = ({ bgColor, pictogram: Pictogram, title, withTabs }) => {
+const PageHeader = ({ bgColor, loading, pictogram: Pictogram, title, withTabs }) => {
   const headerHeight = withTabs ? '272px' : '320px'
 
   let containerStyle = {
@@ -27,9 +27,12 @@ const PageHeader = ({ bgColor, pictogram: Pictogram, title, withTabs }) => {
     <Theme className={styles.container} style={containerStyle} theme={bgColor ? 'white' : 'g100'}>
       <Grid className={styles.grid}>
         <Column className={styles.column} sm={4} md={6} lg={10}>
-          <h1 className={styles.title}>{title}</h1>
+          <div className={styles.section}>
+            {loading && <SkeletonText heading width="256px" />}
+            {!loading && <h1 className={styles.title}>{title}</h1>}
+          </div>
         </Column>
-        {Pictogram && <Pictogram className={styles.pictogram} />}
+        {!loading && Pictogram && <Pictogram className={styles.pictogram} />}
       </Grid>
     </Theme>
   )
@@ -37,8 +40,9 @@ const PageHeader = ({ bgColor, pictogram: Pictogram, title, withTabs }) => {
 
 PageHeader.propTypes = {
   bgColor: PropTypes.string,
+  loading: PropTypes.bool,
   pictogram: PropTypes.object,
-  title: PropTypes.string.isRequired,
+  title: PropTypes.string,
   withTabs: PropTypes.bool
 }
 

--- a/services/web-app/components/page-header/page-header.js
+++ b/services/web-app/components/page-header/page-header.js
@@ -28,7 +28,7 @@ const PageHeader = ({ bgColor, loading, pictogram: Pictogram, title, withTabs })
       <Grid className={styles.grid}>
         <Column className={styles.column} sm={4} md={6} lg={10}>
           <div className={styles.section}>
-            {loading && <SkeletonText heading width="256px" />}
+            {loading && <SkeletonText heading width="256px" className={styles.skeleton} />}
             {!loading && <h1 className={styles.title}>{title}</h1>}
           </div>
         </Column>

--- a/services/web-app/components/page-header/page-header.module.scss
+++ b/services/web-app/components/page-header/page-header.module.scss
@@ -41,8 +41,11 @@
   align-items: flex-end;
 }
 
-.title {
+.section {
   margin-bottom: spacing.$spacing-07;
+}
+
+.title {
   color: theme.$text-primary;
   @include type.type-style('fluid-display-01', true);
   @include mixins.line-clamp(2);

--- a/services/web-app/components/page-header/page-header.module.scss
+++ b/services/web-app/components/page-header/page-header.module.scss
@@ -78,3 +78,10 @@
     display: none;
   }
 }
+
+.skeleton {
+  height: spacing.$spacing-07;
+  @include breakpoint.breakpoint(md) {
+    height: spacing.$spacing-09;
+  }
+}

--- a/services/web-app/components/page-loading/index.js
+++ b/services/web-app/components/page-loading/index.js
@@ -1,0 +1,8 @@
+/*
+ * Copyright IBM Corp. 2022, 2022
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export { default } from './page-loading'

--- a/services/web-app/components/page-loading/page-loading.js
+++ b/services/web-app/components/page-loading/page-loading.js
@@ -1,0 +1,30 @@
+/*
+ * Copyright IBM Corp. 2022, 2022
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { Column, Grid, SkeletonText } from '@carbon/react'
+import PropTypes from 'prop-types'
+
+import styles from './page-loading.module.scss'
+
+const PageLoading = ({ className }) => (
+  <Grid className={className}>
+    <Column sm={4} md={8} lg={8}>
+      <div className={styles['skeleton-text']}>
+        <SkeletonText heading paragraph />
+      </div>
+    </Column>
+  </Grid>
+)
+
+PageLoading.propTypes = {
+  /**
+   * Optional class name.
+   */
+  className: PropTypes.string
+}
+
+export default PageLoading

--- a/services/web-app/components/page-loading/page-loading.module.scss
+++ b/services/web-app/components/page-loading/page-loading.module.scss
@@ -1,0 +1,13 @@
+/*
+ * Copyright IBM Corp. 2022, 2022
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+@use '@carbon/react/scss/spacing' as spacing;
+
+.skeleton-text {
+  padding-top: spacing.$spacing-09;
+  margin-top: spacing.$spacing-07;
+}

--- a/services/web-app/pages/[...remote-mdx-path].js
+++ b/services/web-app/pages/[...remote-mdx-path].js
@@ -5,14 +5,28 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import { useRouter } from 'next/router'
 import { MDXRemote } from 'next-mdx-remote'
 
 import MdxPage from '@/components/mdx-page/mdx-page'
+import PageHeader from '@/components/page-header'
+import PageLoading from '@/components/page-loading'
 import { defaultFilePathPrefix, defaultParams, remotePages } from '@/data/remote-pages'
 import { getRemoteMdxSource } from '@/lib/github'
 import { processMdxSource } from '@/utils/mdx'
 
 const RemoteMdxPage = ({ compiledSource, tabs, mdxError, warnings, pageHeaderType }) => {
+  const router = useRouter()
+
+  if (router.isFallback) {
+    return (
+      <>
+        <PageHeader loading />
+        <PageLoading />
+      </>
+    )
+  }
+
   const frontmatter = compiledSource?.data?.matter || {}
   const { title, description, keywords } = frontmatter
 
@@ -96,7 +110,7 @@ export const getStaticPaths = async () => {
   })
   return {
     paths: allowedPaths,
-    fallback: 'blocking'
+    fallback: true
   }
 }
 

--- a/services/web-app/pages/libraries/[host]/[org]/[repo]/[library]/[ref]/assets/[asset]/[tab].js
+++ b/services/web-app/pages/libraries/[host]/[org]/[repo]/[library]/[ref]/assets/[asset]/[tab].js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 import { Column, Grid } from '@carbon/react'
+import { useRouter } from 'next/router'
 import { MDXRemote } from 'next-mdx-remote'
 import path from 'path'
 import { useContext, useEffect, useRef, useState } from 'react'
@@ -12,10 +13,12 @@ import { useContext, useEffect, useRef, useState } from 'react'
 import MdxPage from '@/components/mdx-page/mdx-page'
 import PageBreadcrumb from '@/components/page-breadcrumb/page-breadcrumb'
 import PageHeader from '@/components/page-header/page-header'
+import PageLoading from '@/components/page-loading'
 import PageNav from '@/components/page-nav'
 import PageTabs from '@/components/page-tabs'
 import { assetTypes } from '@/data/asset-types'
 import { assetsNavData } from '@/data/nav-data'
+import { pageHeaders } from '@/data/page-headers'
 import { LayoutContext } from '@/layouts/layout/layout'
 import { getLibraryData } from '@/lib/github'
 import { getProcessedMdxSource } from '@/utils/mdx'
@@ -25,10 +28,8 @@ import { createUrl } from '@/utils/string'
 import styles from './[tab].module.scss'
 
 const AssetTabPage = ({ source, tabs, assetData }) => {
+  const router = useRouter()
   const [pageNavItems, setPageNavItems] = useState([])
-  const frontmatter = source.compiledSource?.data?.matter || {}
-  const { title, description, keywords } = frontmatter
-
   const { setPrimaryNavData } = useContext(LayoutContext)
   const contentRef = useRef(null)
 
@@ -48,8 +49,21 @@ const AssetTabPage = ({ source, tabs, assetData }) => {
     setPrimaryNavData(assetsNavData)
   }, [setPrimaryNavData])
 
-  const { name } = assetData.content
+  if (router.isFallback) {
+    return (
+      <Grid>
+        <Column sm={4} md={8} lg={{ start: 5, span: 12 }}>
+          {/* We don't know asset type yet, so use the library background color */}
+          <PageHeader bgColor={pageHeaders?.library?.bgColor} loading />
+          <PageLoading />
+        </Column>
+      </Grid>
+    )
+  }
 
+  const frontmatter = source.compiledSource?.data?.matter || {}
+  const { title, description, keywords } = frontmatter
+  const { name } = assetData.content
   const breadcrumbItems = [
     {
       name: getAssetType(assetData).namePlural,
@@ -159,7 +173,7 @@ export const getStaticProps = async ({ params }) => {
 export const getStaticPaths = async () => {
   return {
     paths: [],
-    fallback: 'blocking'
+    fallback: true
   }
 }
 

--- a/services/web-app/pages/libraries/[host]/[org]/[repo]/[library]/[ref]/assets/[asset]/index.js
+++ b/services/web-app/pages/libraries/[host]/[org]/[repo]/[library]/[ref]/assets/[asset]/index.js
@@ -14,19 +14,19 @@ import PropTypes from 'prop-types'
 import { useContext, useEffect, useRef, useState } from 'react'
 
 import AssetDetails from '@/components/asset-details/asset-details'
-import { H1 } from '@/components/markdown'
 import PageBreadcrumb from '@/components/page-breadcrumb'
 import PageHeader from '@/components/page-header'
+import PageLoading from '@/components/page-loading'
 import PageNav from '@/components/page-nav'
 import PageTabs from '@/components/page-tabs'
 import { assetTypes } from '@/data/asset-types'
 import { framework } from '@/data/framework'
 import { assetsNavData } from '@/data/nav-data'
+import { pageHeaders } from '@/data/page-headers'
 import { status } from '@/data/status'
 import { teams } from '@/data/teams'
 import { LayoutContext } from '@/layouts/layout'
 import { getAssetIssueCount, getAssetRelatedFrameworks, getLibraryData } from '@/lib/github'
-import pageStyles from '@/pages/pages.module.scss'
 import { libraryPropTypes, paramsPropTypes } from '@/types'
 import { getProcessedMdxSource } from '@/utils/mdx'
 import { getAssetTabs, getAssetType } from '@/utils/schema'
@@ -40,16 +40,6 @@ const frameworkNameToIconMap = {
   'web-components': 'webcomponents',
   'react-native': 'react'
 }
-
-const Fallback = () => (
-  <Grid>
-    <Column sm={4} md={8} lg={16}>
-      <div className={pageStyles.content}>
-        <H1>Loading...</H1>
-      </div>
-    </Column>
-  </Grid>
-)
 
 const Asset = ({ libraryData, overviewMdxSource, params }) => {
   const { setPrimaryNavData } = useContext(LayoutContext)
@@ -90,7 +80,15 @@ const Asset = ({ libraryData, overviewMdxSource, params }) => {
   }, [libraryData?.assets])
 
   if (router.isFallback) {
-    return <Fallback />
+    return (
+      <Grid>
+        <Column sm={4} md={8} lg={{ start: 5, span: 12 }}>
+          {/* We don't know asset type yet, so use the library background color */}
+          <PageHeader bgColor={pageHeaders?.library?.bgColor} loading />
+          <PageLoading />
+        </Column>
+      </Grid>
+    )
   }
 
   const [assetData] = libraryData.assets
@@ -251,7 +249,7 @@ export const getStaticProps = async ({ params }) => {
 export const getStaticPaths = async () => {
   return {
     paths: [],
-    fallback: 'blocking'
+    fallback: true
   }
 }
 

--- a/services/web-app/pages/libraries/[host]/[org]/[repo]/[library]/[ref]/assets/index.js
+++ b/services/web-app/pages/libraries/[host]/[org]/[repo]/[library]/[ref]/assets/index.js
@@ -26,17 +26,15 @@ import { NextSeo } from 'next-seo'
 import { useContext, useEffect, useState } from 'react'
 
 import AssetCatalogItemMeta from '@/components/asset-catalog-item/asset-catalog-item-meta'
-import H1 from '@/components/markdown/h1'
-import H2 from '@/components/markdown/h2'
-import H3 from '@/components/markdown/h3'
+import { H2, H3 } from '@/components/markdown'
 import PageHeader from '@/components/page-header'
+import PageLoading from '@/components/page-loading'
 import TypeTag from '@/components/type-tag'
 import { assetsNavData } from '@/data/nav-data'
 import { pageHeaders } from '@/data/page-headers'
 import { ALPHABETICAL_ORDER, sortItems } from '@/data/sort'
 import { LayoutContext } from '@/layouts/layout'
 import { getLibraryData, getLibraryNavData } from '@/lib/github'
-import pageStyles from '@/pages/pages.module.scss'
 import { libraryPropTypes, paramsPropTypes, secondaryNavDataPropTypes } from '@/types'
 import { assetSortComparator } from '@/utils/schema'
 import { getAllTags } from '@/utils/schema.js'
@@ -80,21 +78,18 @@ const LibrayAssets = ({ libraryData, params, navData }) => {
     setSecondaryNavData(navData)
   }, [setPrimaryNavData, navData, setSecondaryNavData])
 
+  const pageHeader = pageHeaders?.library ?? {}
+
   if (router.isFallback) {
     return (
-      <Grid>
-        <Column sm={4} md={8} lg={16}>
-          <div className={pageStyles.content}>
-            <H1>Loading...</H1>
-          </div>
-        </Column>
-      </Grid>
+      <>
+        <PageHeader bgColor={pageHeader?.bgColor} loading />
+        <PageLoading />
+      </>
     )
   }
 
   const { description } = libraryData.content
-
-  const pageHeader = pageHeaders?.library ?? {}
 
   const seo = {
     title: 'Assets',
@@ -283,7 +278,7 @@ export const getStaticProps = async ({ params }) => {
 export const getStaticPaths = async () => {
   return {
     paths: [],
-    fallback: 'blocking'
+    fallback: true
   }
 }
 

--- a/services/web-app/pages/libraries/[host]/[org]/[repo]/[library]/[ref]/design-kits.js
+++ b/services/web-app/pages/libraries/[host]/[org]/[repo]/[library]/[ref]/design-kits.js
@@ -15,12 +15,11 @@ import { NextSeo } from 'next-seo'
 import { useContext, useEffect } from 'react'
 
 import CardGroup from '@/components/card-group/card-group'
-import H1 from '@/components/markdown/h1'
-import H2 from '@/components/markdown/h2'
-import P from '@/components/markdown/p'
+import { H2, P } from '@/components/markdown'
 import MdxIcon from '@/components/mdx-icon/mdx-icon'
 import PageDescription from '@/components/page-description/page-description'
 import PageHeader from '@/components/page-header'
+import PageLoading from '@/components/page-loading'
 import ResourceCard from '@/components/resource-card/resource-card'
 import { designKitTypes } from '@/data/design-kit-types'
 import { designTools } from '@/data/design-tools'
@@ -37,12 +36,6 @@ const DesignKits = ({ libraryData, navData }) => {
 
   const pageHeader = pageHeaders?.library ?? {}
 
-  const { name } = libraryData.content
-
-  const seo = {
-    title: `${name} design kits`
-  }
-
   useEffect(() => {
     setPrimaryNavData(assetsNavData)
     setSecondaryNavData(navData)
@@ -50,14 +43,17 @@ const DesignKits = ({ libraryData, navData }) => {
 
   if (router.isFallback) {
     return (
-      <Grid>
-        <Column sm={4} md={8} lg={16}>
-          <div className={pageStyles.content}>
-            <H1>Loading...</H1>
-          </div>
-        </Column>
-      </Grid>
+      <>
+        <PageHeader bgColor={pageHeader?.bgColor} loading />
+        <PageLoading />
+      </>
     )
+  }
+
+  const { name } = libraryData.content
+
+  const seo = {
+    title: `${name} design kits`
   }
 
   let groupedDesignKits
@@ -178,7 +174,7 @@ export const getStaticProps = async ({ params }) => {
 export const getStaticPaths = async () => {
   return {
     paths: [],
-    fallback: 'blocking'
+    fallback: true
   }
 }
 

--- a/services/web-app/pages/libraries/[host]/[org]/[repo]/[library]/[ref]/index.js
+++ b/services/web-app/pages/libraries/[host]/[org]/[repo]/[library]/[ref]/index.js
@@ -18,10 +18,11 @@ import CardGroup from '@/components/card-group'
 import { Dashboard, DashboardItem } from '@/components/dashboard'
 import dashboardStyles from '@/components/dashboard/dashboard.module.scss'
 import DemoLinks from '@/components/demo-links'
-import { H1, H2 } from '@/components/markdown'
+import { H2 } from '@/components/markdown'
 import MdxIcon from '@/components/mdx-icon'
 import PageDescription from '@/components/page-description'
 import PageHeader from '@/components/page-header'
+import PageLoading from '@/components/page-loading'
 import ResourceCard from '@/components/resource-card'
 import { assetsNavData } from '@/data/nav-data'
 import { pageHeaders } from '@/data/page-headers'
@@ -33,7 +34,6 @@ import {
   getLibraryParams,
   getLibraryRelatedLibs
 } from '@/lib/github'
-import pageStyles from '@/pages/pages.module.scss'
 import { libraryPropTypes, paramsPropTypes, secondaryNavDataPropTypes } from '@/types'
 import { getAssetLicense } from '@/utils/schema'
 
@@ -49,21 +49,18 @@ const Library = ({ libraryData, params, navData }) => {
     setSecondaryNavData(navData)
   }, [setPrimaryNavData, navData, setSecondaryNavData])
 
+  const pageHeader = pageHeaders?.library ?? {}
+
   if (router.isFallback) {
     return (
-      <Grid>
-        <Column sm={4} md={8} lg={16}>
-          <div className={pageStyles.content}>
-            <H1>Loading...</H1>
-          </div>
-        </Column>
-      </Grid>
+      <>
+        <PageHeader bgColor={pageHeader?.bgColor} loading />
+        <PageLoading />
+      </>
     )
   }
 
   const { name, description } = libraryData.content
-
-  const pageHeader = pageHeaders?.library ?? {}
 
   const seo = {
     title: name,
@@ -298,7 +295,7 @@ export const getStaticProps = async ({ params }) => {
 export const getStaticPaths = async () => {
   return {
     paths: [],
-    fallback: 'blocking'
+    fallback: true
   }
 }
 

--- a/services/web-app/pages/libraries/[host]/[org]/[repo]/[library]/[ref]/pages/[...page].js
+++ b/services/web-app/pages/libraries/[host]/[org]/[repo]/[library]/[ref]/pages/[...page].js
@@ -4,6 +4,7 @@
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
+import { useRouter } from 'next/router'
 import { MDXRemote } from 'next-mdx-remote'
 import { NextSeo } from 'next-seo'
 import path from 'path'
@@ -11,7 +12,10 @@ import { useContext, useEffect } from 'react'
 import slugify from 'slugify'
 
 import MdxPage from '@/components/mdx-page/mdx-page'
+import PageHeader from '@/components/page-header'
+import PageLoading from '@/components/page-loading'
 import { assetsNavData } from '@/data/nav-data'
+import { pageHeaders } from '@/data/page-headers'
 import { LayoutContext } from '@/layouts/layout/layout'
 import { getLibraryData, getLibraryNavData, getRemoteMdxSource } from '@/lib/github'
 import { processMdxSource } from '@/utils/mdx'
@@ -19,10 +23,7 @@ import { createUrl } from '@/utils/string'
 import { dfs } from '@/utils/tree'
 
 const LibraryPage = ({ compiledSource, mdxError, warnings, navData, navTitle, libraryData }) => {
-  const seo = {
-    title: `${libraryData?.content?.name ?? ''} - ${navTitle}`
-  }
-
+  const router = useRouter()
   const { setPrimaryNavData, setSecondaryNavData } = useContext(LayoutContext)
 
   useEffect(() => {
@@ -30,8 +31,21 @@ const LibraryPage = ({ compiledSource, mdxError, warnings, navData, navTitle, li
     setSecondaryNavData(navData)
   }, [setPrimaryNavData, navData, setSecondaryNavData])
 
+  if (router.isFallback) {
+    return (
+      <>
+        <PageHeader bgColor={pageHeaders?.library?.bgColor} loading />
+        <PageLoading />
+      </>
+    )
+  }
+
+  const seo = {
+    title: `${libraryData?.content?.name ?? ''} - ${navTitle}`
+  }
   const frontmatter = compiledSource?.data?.matter || {}
   const { title, description, keywords } = frontmatter
+
   return (
     <>
       <NextSeo {...seo} />
@@ -122,7 +136,7 @@ export const getStaticProps = async ({ params }) => {
 export const getStaticPaths = async () => {
   return {
     paths: [],
-    fallback: 'blocking'
+    fallback: true
   }
 }
 


### PR DESCRIPTION
Closes #1313

This PR enables ISR fallbacks.

#### Changelog

**New**

- `PageLoading` component with a multiple line skeleton

**Changed**

- `NavPrimary` skeleton when there's no primary nav data
- `NavSecondary` skeleton when there's no secondary nav data
- `PageHeader` loading state
- Fallbacks used in ISR pages:
  - Remote MDX
  - Library
  - Library > Assets
  - Library > Design kits
  - Library > Page
  - Library > Asset
  - Library > Asset > Tab

**Removed**

- N/A

#### Testing / reviewing

See comments below for examples.
