### PR TITLE
fix(web-app): filter text font size

### DIFF
--- a/services/web-app/components/catalog-multislect-filter/catalog-multiselect-filter.module.scss
+++ b/services/web-app/components/catalog-multislect-filter/catalog-multiselect-filter.module.scss
@@ -65,7 +65,7 @@
   flex-grow: 1;
   color: theme.$text-primary;
   text-align: left;
-  @include type.type-style('body-compact-02');
+  @include type.type-style('body-compact-01');
 }
 
 .tag {


### PR DESCRIPTION
closes #1294

#### Testing / reviewing

Test that filter dropdown text in catalogs is using correct type token (body-compact-01)

http://localhost:3000/assets/functions
