### PR TITLE
fix(web-app): remove border-top resource card on mobile

### DIFF
--- a/services/web-app/components/resource-card/resource-card-group.module.scss
+++ b/services/web-app/components/resource-card/resource-card-group.module.scss
@@ -26,7 +26,10 @@
     border-top: 1px solid theme.$border-subtle;
   }
 
-  :global([class*='cds--lg:col-span-4']:first-child) .resource-card,
+  :global([class*='cds--lg:col-span-4']:first-child) .resource-card {
+    border-top: 0 solid transparent;
+  }
+
   :global([class*='cds--lg:col-span-4']:nth-child(2)) .resource-card {
     @include breakpoint.breakpoint('md') {
       border-top: 0 solid transparent;


### PR DESCRIPTION
closes #1297

- remove top border at mobile above resource card

#### Testing / reviewing

Test at mobile http://localhost:3000/data-visualization/get-started
