### PR TITLE
fix(web-app): padding for cite element inside blockquote

### DIFF
--- a/services/web-app/components/markdown/markdown.module.scss
+++ b/services/web-app/components/markdown/markdown.module.scss
@@ -124,6 +124,7 @@
   @include type.type-style('body-long-01');
 
   display: block;
+  padding-left: spacing.$spacing-05;
   margin-top: spacing.$spacing-02;
   font-style: italic;
   text-indent: 0;


### PR DESCRIPTION
closes #1298

Closes #

Fix alignment `cite` inside `blockquote`

#### Testing / reviewing
http://localhost:3000/guidelines/content/writing-style#use-sentence-case-capitalization
