### PR TITLE
fix(web-app): sort by left padding on asset list

### DIFF
--- a/services/web-app/pages/libraries/[host]/[org]/[repo]/[library]/[ref]/assets/index.module.scss
+++ b/services/web-app/pages/libraries/[host]/[org]/[repo]/[library]/[ref]/assets/index.module.scss
@@ -58,7 +58,7 @@
   position: relative;
   display: flex;
   width: 100%;
-  padding-left: spacing.$spacing-05;
+
   grid-gap: 0;
 
   // overide carbon color


### PR DESCRIPTION
closes #1339



#### Testing / reviewing

Check left padding for sort by at all breakpoints
http://localhost:3000/libraries/carbon-components-angular/latest/assets