### PR TITLE
fix(web-app): remove top border in library catalog first item

### DIFF
--- a/services/web-app/components/library-catalog-item/library-catalog-item.js
+++ b/services/web-app/components/library-catalog-item/library-catalog-item.js
@@ -6,7 +6,9 @@
  */
 import { AspectRatio, Column, Grid } from '@carbon/react'
 import { Events, Scales } from '@carbon/react/icons'
+import clsx from 'clsx'
 import isEmpty from 'lodash/isEmpty'
+import PropTypes from 'prop-types'
 
 import { teams } from '@/data/teams'
 import { libraryPropTypes } from '@/types'
@@ -15,7 +17,7 @@ import { mediaQueries, useMatchMedia } from '@/utils/use-match-media'
 
 import styles from './library-catalog-item.module.scss'
 
-const LibraryCatalogItem = ({ library = {} }) => {
+const LibraryCatalogItem = ({ library = {}, index }) => {
   const isMd = useMatchMedia(mediaQueries.md)
 
   if (isEmpty(library)) return null
@@ -53,7 +55,12 @@ const LibraryCatalogItem = ({ library = {} }) => {
 
   return (
     <Column as="li" sm={4} md={8} lg={12}>
-      <a className={styles.anchor} href={`/libraries/${library.params.library}`}>
+      <a
+        className={clsx(styles.anchor, {
+          [styles['no-border']]: index === 0
+        })}
+        href={`/libraries/${library.params.library}`}
+      >
         {isMd && <div>{renderContent()}</div>}
         {!isMd && <AspectRatio ratio="3x2">{renderContent()}</AspectRatio>}
       </a>
@@ -68,6 +75,10 @@ LibraryCatalogItem.defaultPropTypes = {
 }
 
 LibraryCatalogItem.propTypes = {
+  /**
+   * Index of item in list
+   */
+  index: PropTypes.number,
   /**
    * Library item to render.
    */

--- a/services/web-app/components/library-catalog-item/library-catalog-item.module.scss
+++ b/services/web-app/components/library-catalog-item/library-catalog-item.module.scss
@@ -37,6 +37,10 @@
   }
 }
 
+.no-border {
+  border-top: none;
+}
+
 .content {
   padding: spacing.$spacing-05 spacing.$spacing-05 spacing.$spacing-05 0;
   @include breakpoint.breakpoint(md) {

--- a/services/web-app/components/library-catalog/library-catalog.js
+++ b/services/web-app/components/library-catalog/library-catalog.js
@@ -149,7 +149,11 @@ const LibraryCatalog = ({ libraries }) => {
   }
 
   const renderLibrary = (library, index) => (
-    <LibraryCatalogItem library={library} key={`${index}-${getSlug(library.content)}`} />
+    <LibraryCatalogItem
+      library={library}
+      index={index}
+      key={`${index}-${getSlug(library.content)}`}
+    />
   )
 
   return (


### PR DESCRIPTION
Closes #1301

We actually steered away from the gh pages route and are now deploying directly to an IBM Cloud Object Storage bucket that servers the files as a static website, which saves us the trouble of having to create a new repository to host the files 🔥 .

We'll do the same thing for pr storybook deployments using a different bucket

#### Testing / reviewing

http://localhost:3000/libraries