### PR TITLE
fix: remove nav skeletons

### DIFF
--- a/services/web-app/components/nav-primary/nav-primary.js
+++ b/services/web-app/components/nav-primary/nav-primary.js
@@ -5,9 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { HeaderSideNavItems, SideNav, SideNavItems, SideNavLink, SkeletonText } from '@carbon/react'
+import { HeaderSideNavItems, SideNav, SideNavItems, SideNavLink } from '@carbon/react'
 import clsx from 'clsx'
-import isEmpty from 'lodash/isEmpty'
 import { useRouter } from 'next/router'
 import PropTypes from 'prop-types'
 import { useContext } from 'react'
@@ -21,7 +20,6 @@ const NavPrimary = ({ className, globalItems }) => {
   const router = useRouter()
   const { isSideNavExpanded, primaryNavData, isSecondaryNav, setSideNavExpanded } =
     useContext(LayoutContext)
-  const isLoading = isEmpty(primaryNavData)
 
   return (
     <SideNav
@@ -56,12 +54,7 @@ const NavPrimary = ({ className, globalItems }) => {
             })}
           </HeaderSideNavItems>
         )}
-        {isLoading && (
-          <div className={styles.skeleton}>
-            <SkeletonText paragraph />
-          </div>
-        )}
-        {!isLoading && primaryNavData && primaryNavData.length > 0 && (
+        {primaryNavData && primaryNavData.length > 0 && (
           <NavTree items={primaryNavData} label="Main navigation" activeItem={router.asPath} />
         )}
       </SideNavItems>

--- a/services/web-app/components/nav-primary/nav-primary.module.scss
+++ b/services/web-app/components/nav-primary/nav-primary.module.scss
@@ -32,7 +32,3 @@
     outline: none !important;
   }
 }
-
-.skeleton {
-  padding: spacing.$spacing-03 spacing.$spacing-05;
-}

--- a/services/web-app/components/nav-secondary/nav-secondary.js
+++ b/services/web-app/components/nav-secondary/nav-secondary.js
@@ -5,10 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { Button, SideNav, SkeletonText } from '@carbon/react'
+import { Button, SideNav } from '@carbon/react'
 import { ArrowLeft } from '@carbon/react/icons'
 import clsx from 'clsx'
-import isEmpty from 'lodash/isEmpty'
 import { useRouter } from 'next/router'
 import { useContext } from 'react'
 
@@ -23,7 +22,6 @@ const NavSecondary = ({ className, visible, onSlidePrimary }) => {
   const { isSideNavExpanded, secondaryNavData = {}, setSideNavExpanded } = useContext(LayoutContext)
   const isLg = useMatchMedia(mediaQueries.lg)
 
-  const isLoading = isEmpty(secondaryNavData)
   const { back, headings, items, path } = secondaryNavData
 
   // $duration-moderate-01 = 150ms
@@ -38,17 +36,25 @@ const NavSecondary = ({ className, visible, onSlidePrimary }) => {
 
   if (!isLg && !visible) return null
 
-  const renderContent = () => (
-    <>
-      <Button
-        kind="ghost"
-        onClick={handleBack}
-        className={styles.back}
-        tabIndex={visible ? 0 : '-1'}
-      >
-        <ArrowLeft className={styles['back-icon']} size={16} />
-        {back?.title ?? 'Back'}
-      </Button>
+  return (
+    <SideNav
+      aria-label="Secondary side navigation"
+      expanded={isSideNavExpanded}
+      className={clsx(styles['secondary-nav'], className)}
+      aria-hidden={visible ? 'false' : 'true'}
+      onOverlayClick={() => setSideNavExpanded(false)}
+    >
+      {back && (
+        <Button
+          kind="ghost"
+          onClick={handleBack}
+          className={styles.back}
+          tabIndex={visible ? 0 : '-1'}
+        >
+          <ArrowLeft className={styles['back-icon']} size={16} />
+          {back?.title ?? 'Back'}
+        </Button>
+      )}
       {headings && (
         <a
           className={clsx(
@@ -68,23 +74,6 @@ const NavSecondary = ({ className, visible, onSlidePrimary }) => {
         </a>
       )}
       {items && <NavTree items={items} label="Secondary navigation" activeItem={router.asPath} />}
-    </>
-  )
-
-  return (
-    <SideNav
-      aria-label="Secondary side navigation"
-      expanded={isSideNavExpanded}
-      className={clsx(styles['secondary-nav'], className)}
-      aria-hidden={visible ? 'false' : 'true'}
-      onOverlayClick={() => setSideNavExpanded(false)}
-    >
-      {isLoading && (
-        <div className={styles.skeleton}>
-          <SkeletonText paragraph />
-        </div>
-      )}
-      {!isLoading && renderContent()}
     </SideNav>
   )
 }

--- a/services/web-app/components/nav-secondary/nav-secondary.module.scss
+++ b/services/web-app/components/nav-secondary/nav-secondary.module.scss
@@ -116,8 +116,3 @@
 
   display: block;
 }
-
-.skeleton {
-  padding: spacing.$spacing-05;
-  margin: spacing.$spacing-02 0;
-}


### PR DESCRIPTION
Removes primary and secondary nav skeletons while data is loading, because that becomes distracting as the entire web-app re-hydrates between page loads now.

#### Changelog

**New**

- NA

**Changed**

- NA

**Removed**

- Primary and secondary nav loading skeletons

#### Testing / reviewing

Navigate among about pages, and pages in a library, and make sure that side navs remain white while loading.
