### PR TITLE
fix: website to platform redirect

### DIFF
--- a/services/web-app/config/redirects.mjs
+++ b/services/web-app/config/redirects.mjs
@@ -94,6 +94,10 @@ const websiteToPlatformRedirects = [
   ],
   // Component removed code tabs, must come after the redirects that end in `/code`
   ['/components/:component/code', '/libraries/carbon-react/latest/assets/:component'],
+  [
+    '/libraries/carbon-react/latest/assets/ordered-list/code',
+    '/libraries/carbon-react/latest/assets/ordered-list'
+  ],
   // Component catalog
   ['/components/overview', '/assets/components'],
   // Component default redirect, must come after all other `/components` redirects


### PR DESCRIPTION
Closes #907 

This is the only carbon-platform code change needed to close 907.

#### Changelog

**New**

- `/components/list/code` redirect now works

**Changed**

- None

**Removed**

- None

#### Testing / reviewing

Remember to disable network cache in Chrome dev tools, with Chrome dev tools open, when testing any redirects.