### PR TITLE
docs: update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -8,11 +8,11 @@ assignees: ''
 
 **Description**
 
-Tell us more about the problem that you're running into. What did you see? What did you expect to
-see?
+> Tell us more about the problem that you're running into. What did you see? What did you expect to
+> see?
 
 **Steps to reproduce**
 
-How do we reproduce the error? Please be as specific as you can.
+> How do we reproduce the error? Please be as specific as you can.
 
 1. To do

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,6 +3,9 @@ contact_links:
   - name: Carbon Platform roadmap
     url: https://app.zenhub.com/workspaces/platform-product-management-624ca9397d28730018df40c2/roadmap
     about: Learn what we're working on and what we have planned for the future.
-  - name: Carbon feedback
+  - name: Carbon Platform feedback
+    url: https://github.com/carbon-design-system/carbon-platform/discussions
+    about: Share your feedback with the Carbon Platform squad.
+  - name: Carbon System feedback
     url: https://github.com/carbon-design-system/carbon/discussions
-    about: Share your feedback with the Carbon team.
+    about: Share your feedback with the Carbon System squad.

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -15,7 +15,7 @@ assignees: ''
 
 > What value will this deliver?
 
-1. When _, I want to _, so I can \_.
+1. When \_, I want to \_, so I can \_.
 
 **Acceptance criteria**
 

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -8,17 +8,17 @@ assignees: ''
 
 **Summary**
 
-What problem (or opportunity) are we solving? Why are we solving it? Is there supporting user
-conversations or research?
+> What problem (or opportunity) are we solving? Why are we solving it? Is there supporting user
+> conversations or research?
 
 **Job stories**
 
-What value will this deliver?
+> What value will this deliver?
 
-1. When \_\_\_, I want to \_\_\_, so I can \_\_\_.
+1. When _, I want to _, so I can \_.
 
 **Acceptance criteria**
 
-What requirements must be met to complete this request?
+> What requirements must be met to complete this request?
 
 1. To do


### PR DESCRIPTION
Updates GitHub issue templates.

#### Changelog

**New**

- https://github.com/carbon-design-system/carbon-platform/issues/new/choose to link to this repo's Discussions

**Changed**

- Issue template formatting so the prompts can stay in the issue, just like what we do with the tech design template

**Removed**

- N/A

#### Testing / reviewing

N/A
