### PR TITLE
feat(web-app): add global content wrapper for consistent spacing

### DIFF
--- a/services/web-app/components/asset-details/asset-details.js
+++ b/services/web-app/components/asset-details/asset-details.js
@@ -13,6 +13,7 @@ import { useRouter } from 'next/router'
 import { MDXRemote } from 'next-mdx-remote'
 import PropTypes from 'prop-types'
 
+import ContentWrapper from '@/components/content-wrapper'
 import { Dashboard, DashboardItem } from '@/components/dashboard'
 import dashboardStyles from '@/components/dashboard/dashboard.module.scss'
 import DemoLinks from '@/components/demo-links'
@@ -62,7 +63,7 @@ const AssetDetails = ({ library, asset }) => {
   const router = useRouter()
 
   return (
-    <>
+    <ContentWrapper>
       <section id="dashboard">
         <Dashboard className={styles.dashboard}>
           <Column className={dashboardStyles.column} sm={4}>
@@ -196,7 +197,7 @@ const AssetDetails = ({ library, asset }) => {
           <MDXRemote compiledSource={asset.overviewMdxSource.compiledSource.value} />
         )}
       </section>
-    </>
+    </ContentWrapper>
   )
 }
 

--- a/services/web-app/components/asset-details/asset-details.module.scss
+++ b/services/web-app/components/asset-details/asset-details.module.scss
@@ -10,12 +10,7 @@
 @use '@carbon/react/scss/utilities/convert' as convert;
 
 .dashboard {
-  margin-top: spacing.$spacing-07;
   margin-bottom: spacing.$spacing-07;
-
-  @include breakpoint.breakpoint(lg) {
-    margin-top: spacing.$spacing-11;
-  }
 }
 
 .maintainer-icon {

--- a/services/web-app/components/content-wrapper/content-wrapper.js
+++ b/services/web-app/components/content-wrapper/content-wrapper.js
@@ -1,0 +1,12 @@
+/*
+ * Copyright IBM Corp. 2022, 2022
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import styles from './content-wrapper.module.scss'
+
+const ContentWrapper = ({ children }) => <div className={styles['content-wrapper']}>{children}</div>
+
+export default ContentWrapper

--- a/services/web-app/components/content-wrapper/content-wrapper.module.scss
+++ b/services/web-app/components/content-wrapper/content-wrapper.module.scss
@@ -21,6 +21,5 @@
 .content-wrapper > *:first-child > *:first-child,
 .content-wrapper > *:first-child > *:first-child > *:first-child,
 .content-wrapper > *:first-child > *:first-child > *:first-child > *:first-child {
-  padding-top: 0;
   margin-top: 0;
 }

--- a/services/web-app/components/content-wrapper/content-wrapper.module.scss
+++ b/services/web-app/components/content-wrapper/content-wrapper.module.scss
@@ -19,7 +19,8 @@
 //remove default spacing on first elements
 .content-wrapper > *:first-child,
 .content-wrapper > *:first-child > *:first-child,
-.content-wrapper > *:first-child > *:first-child > *:first-child {
+.content-wrapper > *:first-child > *:first-child > *:first-child,
+.content-wrapper > *:first-child > *:first-child > *:first-child > *:first-child {
   padding-top: 0;
   margin-top: 0;
 }

--- a/services/web-app/components/content-wrapper/content-wrapper.module.scss
+++ b/services/web-app/components/content-wrapper/content-wrapper.module.scss
@@ -1,0 +1,25 @@
+/*
+ * Copyright IBM Corp. 2022, 2022
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+@use '@carbon/react/scss/spacing' as spacing;
+@use '@carbon/react/scss/breakpoint' as breakpoint;
+
+.content-wrapper {
+  margin-top: spacing.$spacing-07;
+
+  @include breakpoint.breakpoint(lg) {
+    margin-top: spacing.$spacing-11;
+  }
+}
+
+//remove default spacing on first elements
+.content-wrapper > *:first-child,
+.content-wrapper > *:first-child > *:first-child,
+.content-wrapper > *:first-child > *:first-child > *:first-child {
+  padding-top: 0;
+  margin-top: 0;
+}

--- a/services/web-app/components/content-wrapper/index.js
+++ b/services/web-app/components/content-wrapper/index.js
@@ -5,8 +5,4 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-@use '@carbon/react/scss/spacing' as spacing;
-
-.page-content {
-  padding-top: spacing.$spacing-09;
-}
+export { default } from './content-wrapper'

--- a/services/web-app/components/mdx-page/mdx-page.js
+++ b/services/web-app/components/mdx-page/mdx-page.js
@@ -12,6 +12,7 @@ import PropTypes from 'prop-types'
 import { useContext, useEffect } from 'react'
 import slugify from 'slugify'
 
+import ContentWrapper from '@/components/content-wrapper'
 import PageHeader from '@/components/page-header'
 import PageTabs from '@/components/page-tabs'
 import { assetsNavData } from '@/data/nav-data'
@@ -24,7 +25,6 @@ import FallbackExceptionContent from './errors/fallback-exception-content'
 import ImportFoundExceptionContent from './errors/import-found-exception-content'
 import MdxCompileExceptionContent from './errors/mdx-compile-exception-content'
 import WarningsRollup from './errors/warnings-rollup'
-import styles from './mdx-page.module.scss'
 
 const getTabData = (tabs, baseSegment) => {
   return tabs.map((tab) => {
@@ -63,10 +63,10 @@ const createPageContent = ({ children, mdxError, warnings }) => {
   }
 
   return (
-    <div className={styles['page-content']}>
+    <ContentWrapper>
       {warnings?.length > 0 && <WarningsRollup warnings={warnings} />}
       {children}
-    </div>
+    </ContentWrapper>
   )
 }
 

--- a/services/web-app/components/svg-libraries/svg-library.module.scss
+++ b/services/web-app/components/svg-libraries/svg-library.module.scss
@@ -10,7 +10,6 @@
 .svg-page {
   // prevent jank while importing icons
   min-height: 60vh;
-  padding-top: spacing.$spacing-07;
 }
 
 @media screen and (prefers-reduced-motion: reduce) {

--- a/services/web-app/layouts/layout/layout.js
+++ b/services/web-app/layouts/layout/layout.js
@@ -169,7 +169,7 @@ const Layout = ({ children }) => {
         <>
           {router.pathname === '/' && <Banner />}
           <Theme theme="g100">
-            <Header aria-label="Carbon Design System" className={styles.header}>
+            <Header aria-label="Carbon Design System">
               <SkipToContent />
               {showSideNav && (
                 <div>

--- a/services/web-app/pages/about-carbon/platform-roadmap.js
+++ b/services/web-app/pages/about-carbon/platform-roadmap.js
@@ -9,6 +9,7 @@ import Image from 'next/image'
 import { NextSeo } from 'next-seo'
 import { useContext, useEffect } from 'react'
 
+import ContentWrapper from '@/components/content-wrapper'
 import Divider from '@/components/divider/divider'
 import H2 from '@/components/markdown/h2'
 import H3 from '@/components/markdown/h3'
@@ -157,7 +158,7 @@ const PageContent = () => {
   ]
 
   return (
-    <div>
+    <ContentWrapper>
       <Grid>
         <Column sm={4} md={8}>
           <p className={styles['intro-copy']}>
@@ -231,7 +232,7 @@ const PageContent = () => {
           </Grid>
         </Divider>
       ))}
-    </div>
+    </ContentWrapper>
   )
 }
 

--- a/services/web-app/pages/libraries/[host]/[org]/[repo]/[library]/[ref]/assets/[asset]/[tab].js
+++ b/services/web-app/pages/libraries/[host]/[org]/[repo]/[library]/[ref]/assets/[asset]/[tab].js
@@ -90,11 +90,7 @@ const AssetTabPage = ({ source, tabs, assetData }) => {
             warnings={source.warnings}
             seoTitle={title ?? `${assetData.content.name} - Usage`}
           >
-            {source.compiledSource && (
-              <div className={styles['page-content']}>
-                <MDXRemote compiledSource={source.compiledSource.value} />
-              </div>
-            )}
+            {source.compiledSource && <MDXRemote compiledSource={source.compiledSource.value} />}
           </MdxPage>
         </Column>
       </Grid>

--- a/services/web-app/pages/libraries/[host]/[org]/[repo]/[library]/[ref]/assets/[asset]/[tab].module.scss
+++ b/services/web-app/pages/libraries/[host]/[org]/[repo]/[library]/[ref]/assets/[asset]/[tab].module.scss
@@ -9,10 +9,6 @@
 @use '@carbon/react/scss/utilities/convert' as convert;
 @use '@carbon/react/scss/theme' as theme;
 
-.page-content {
-  padding-top: spacing.$spacing-09;
-}
-
 .asset-tabs {
   &::before {
     position: absolute;

--- a/services/web-app/pages/libraries/[host]/[org]/[repo]/[library]/[ref]/assets/index.js
+++ b/services/web-app/pages/libraries/[host]/[org]/[repo]/[library]/[ref]/assets/index.js
@@ -24,6 +24,7 @@ import { NextSeo } from 'next-seo'
 import { useContext, useEffect, useState } from 'react'
 
 import AssetCatalogItemMeta from '@/components/asset-catalog-item/asset-catalog-item-meta'
+import ContentWrapper from '@/components/content-wrapper'
 import H2 from '@/components/markdown/h2'
 import H3 from '@/components/markdown/h3'
 import PageHeader from '@/components/page-header'
@@ -141,92 +142,94 @@ const LibrayAssets = ({ libraryData, params, navData }) => {
           />
         </Column>
         <Column sm={4} md={8} lg={12}>
-          <Grid>
-            <Column sm={4} md={8} lg={8}>
-              <H2 headingClassName={styles.subheading}>{description}</H2>
-            </Column>
-          </Grid>
-          <Grid condensed={!isLg} narrow={isLg}>
-            <Column className={styles['sort-column']} sm={4} md={4} lg={4}>
-              <Dropdown
-                id="catalog-sort"
-                className={styles.dropdown}
-                initialSelectedItem={sortItems.find((item) => item.id === sort)}
-                items={sortItems}
-                itemToString={(item) => (item ? item.text : '')}
-                onChange={({ selectedItem }) => {
-                  onSort(selectedItem.id)
-                }}
-                type="inline"
-                titleText="Sort by:"
-                label="A–Z"
-                size="lg"
-              />
-            </Column>
-          </Grid>
-          <Grid condensed={!isLg} narrow={isLg} className={styles.container}>
-            <Column sm={4} md={8} lg={12}>
-              <DataTable rows={assets} headers={headerData}>
-                {({ rows, headers, getHeaderProps, getTableProps }) => (
-                  <TableContainer>
-                    <Table {...getTableProps()}>
-                      <TableHead>
-                        <TableRow>
-                          {headers.map((header) => (
-                            <TableHeader {...getHeaderProps({ header })} key={header.id}>
-                              {header.header}
-                            </TableHeader>
-                          ))}
-                        </TableRow>
-                      </TableHead>
-                      <TableBody>
-                        {rows.length > 0 &&
-                          rows.map((row) => (
-                            <TableRow key={row.id} className={styles['asset-row']}>
-                              {row.cells.map((cell) => (
-                                <TableCell key={cell.id}>{cell.value}</TableCell>
-                              ))}
-                            </TableRow>
-                          ))}
-                        {rows.length <= 0 && (
+          <ContentWrapper>
+            <Grid>
+              <Column sm={4} md={8} lg={8}>
+                <H2 headingClassName={styles.subheading}>{description}</H2>
+              </Column>
+            </Grid>
+            <Grid condensed={!isLg} narrow={isLg}>
+              <Column className={styles['sort-column']} sm={4} md={4} lg={4}>
+                <Dropdown
+                  id="catalog-sort"
+                  className={styles.dropdown}
+                  initialSelectedItem={sortItems.find((item) => item.id === sort)}
+                  items={sortItems}
+                  itemToString={(item) => (item ? item.text : '')}
+                  onChange={({ selectedItem }) => {
+                    onSort(selectedItem.id)
+                  }}
+                  type="inline"
+                  titleText="Sort by:"
+                  label="A–Z"
+                  size="lg"
+                />
+              </Column>
+            </Grid>
+            <Grid condensed={!isLg} narrow={isLg} className={styles.container}>
+              <Column sm={4} md={8} lg={12}>
+                <DataTable rows={assets} headers={headerData}>
+                  {({ rows, headers, getHeaderProps, getTableProps }) => (
+                    <TableContainer>
+                      <Table {...getTableProps()}>
+                        <TableHead>
                           <TableRow>
-                            <TableCell colSpan={5}>
-                              <div className={styles['no-results-container']}>
-                                <FilingCabinet />
-                                <H2
-                                  narrow
-                                  className={styles['h2-container']}
-                                  headingClassName={styles['no-results-heading']}
-                                >
-                                  No assets in library.
-                                </H2>
-                                <H3
-                                  narrow
-                                  className={styles['h3-container']}
-                                  headingClassName={styles['no-results-subheading']}
-                                >
-                                  This library does not contain any assets.
-                                </H3>
-                                {/* library maintainers should be a link but leaving as text for
-                                now until we figure out contributors discussion */}
-                                <H3
-                                  narrow
-                                  className={styles['h3-container']}
-                                  headingClassName={styles['no-results-subheading']}
-                                >
-                                  Contact library maintainers for further details.
-                                </H3>
-                              </div>
-                            </TableCell>
+                            {headers.map((header) => (
+                              <TableHeader {...getHeaderProps({ header })} key={header.id}>
+                                {header.header}
+                              </TableHeader>
+                            ))}
                           </TableRow>
-                        )}
-                      </TableBody>
-                    </Table>
-                  </TableContainer>
-                )}
-              </DataTable>
-            </Column>
-          </Grid>
+                        </TableHead>
+                        <TableBody>
+                          {rows.length > 0 &&
+                            rows.map((row) => (
+                              <TableRow key={row.id} className={styles['asset-row']}>
+                                {row.cells.map((cell) => (
+                                  <TableCell key={cell.id}>{cell.value}</TableCell>
+                                ))}
+                              </TableRow>
+                            ))}
+                          {rows.length <= 0 && (
+                            <TableRow>
+                              <TableCell colSpan={5}>
+                                <div className={styles['no-results-container']}>
+                                  <FilingCabinet />
+                                  <H2
+                                    narrow
+                                    className={styles['h2-container']}
+                                    headingClassName={styles['no-results-heading']}
+                                  >
+                                    No assets in library.
+                                  </H2>
+                                  <H3
+                                    narrow
+                                    className={styles['h3-container']}
+                                    headingClassName={styles['no-results-subheading']}
+                                  >
+                                    This library does not contain any assets.
+                                  </H3>
+                                  {/* library maintainers should be a link but leaving as text for
+                                now until we figure out contributors discussion */}
+                                  <H3
+                                    narrow
+                                    className={styles['h3-container']}
+                                    headingClassName={styles['no-results-subheading']}
+                                  >
+                                    Contact library maintainers for further details.
+                                  </H3>
+                                </div>
+                              </TableCell>
+                            </TableRow>
+                          )}
+                        </TableBody>
+                      </Table>
+                    </TableContainer>
+                  )}
+                </DataTable>
+              </Column>
+            </Grid>
+          </ContentWrapper>
         </Column>
       </Grid>
     </>

--- a/services/web-app/pages/libraries/[host]/[org]/[repo]/[library]/[ref]/design-kits.js
+++ b/services/web-app/pages/libraries/[host]/[org]/[repo]/[library]/[ref]/design-kits.js
@@ -14,6 +14,7 @@ import { NextSeo } from 'next-seo'
 import { useContext, useEffect } from 'react'
 
 import CardGroup from '@/components/card-group/card-group'
+import ContentWrapper from '@/components/content-wrapper'
 import H2 from '@/components/markdown/h2'
 import P from '@/components/markdown/p'
 import MdxIcon from '@/components/mdx-icon/mdx-icon'
@@ -27,8 +28,6 @@ import { assetsNavData } from '@/data/nav-data'
 import { pageHeaders } from '@/data/page-headers'
 import { LayoutContext } from '@/layouts/layout'
 import { getLibraryData, getLibraryNavData } from '@/lib/github'
-
-import pageStyles from '../../../../../../pages.module.scss'
 
 const DesignKits = ({ libraryData, navData }) => {
   const { setPrimaryNavData, setSecondaryNavData } = useContext(LayoutContext)
@@ -81,9 +80,9 @@ const DesignKits = ({ libraryData, navData }) => {
     <>
       <NextSeo {...seo} />
       <PageHeader bgColor={pageHeader?.bgColor} title="Design kits" pictogram={pageHeader?.icon} />
-      <Grid>
-        <Column sm={4} md={8} lg={12}>
-          <div className={pageStyles.content}>
+      <ContentWrapper>
+        <Grid>
+          <Column sm={4} md={8} lg={12}>
             {!libraryData.content.designKits && <NoDesignKits />}
             {libraryData.content.designKits && (
               <>
@@ -127,9 +126,9 @@ const DesignKits = ({ libraryData, navData }) => {
                 ))}
               </>
             )}
-          </div>
-        </Column>
-      </Grid>
+          </Column>
+        </Grid>
+      </ContentWrapper>
     </>
   )
 }

--- a/services/web-app/pages/libraries/[host]/[org]/[repo]/[library]/[ref]/index.js
+++ b/services/web-app/pages/libraries/[host]/[org]/[repo]/[library]/[ref]/index.js
@@ -14,6 +14,7 @@ import { NextSeo } from 'next-seo'
 import { useContext, useEffect } from 'react'
 
 import CardGroup from '@/components/card-group'
+import ContentWrapper from '@/components/content-wrapper'
 import { Dashboard, DashboardItem } from '@/components/dashboard'
 import dashboardStyles from '@/components/dashboard/dashboard.module.scss'
 import DemoLinks from '@/components/demo-links'
@@ -116,127 +117,132 @@ const Library = ({ libraryData, params, navData }) => {
             pictogram={pageHeader?.icon}
           />
         </Column>
-        <Column sm={4} md={8} lg={8}>
-          <PageDescription className={styles['page-description']}>
-            {seo.description}
-          </PageDescription>
-          <AnchorLinks>
-            <AnchorLink>Dashboard</AnchorLink>
-            {libraryData.content.demoLinks && <AnchorLink>Demo links</AnchorLink>}
-            <AnchorLink>Resources</AnchorLink>
-          </AnchorLinks>
-        </Column>
-        <Column sm={4} md={8} lg={12}>
-          <div id="dashboard">
-            <Dashboard className={styles.dashboard}>
-              <Column className={dashboardStyles.column} sm={4}>
-                <DashboardItem aspectRatio={{ sm: '2x1', md: '1x1', lg: '3x4', xlg: '1x1' }}>
-                  <dl>
-                    <dt className={dashboardStyles.label}>Version</dt>
-                    <dd className={dashboardStyles['label--large']}>{getVersion()}</dd>
-                  </dl>
-                  {MaintainerIcon && (
-                    <MaintainerIcon
-                      className={clsx(
-                        dashboardStyles['position-bottom-left'],
-                        styles['maintainer-icon']
-                      )}
-                      size={64}
-                    />
-                  )}
-                </DashboardItem>
-              </Column>
-              <Column className={dashboardStyles.column} sm={4} lg={8}>
-                <DashboardItem aspectRatio={{ sm: '3x4', md: '3x4', lg: 'none', xlg: 'none' }}>
-                  <Grid as="dl" className={dashboardStyles.subgrid}>
-                    <Column className={dashboardStyles.subcolumn} sm={2} lg={4}>
-                      <dt className={dashboardStyles.label}>Maintainer</dt>
-                      <dd className={dashboardStyles.meta}>
-                        {teams[libraryData.params.maintainer]?.name || 'Community'}
-                      </dd>
-                    </Column>
-                    <Column className={dashboardStyles.subcolumn} sm={2} lg={4}>
-                      <dt className={dashboardStyles.label}>License</dt>
-                      <dd className={dashboardStyles.meta}>{getAssetLicense(libraryData)}</dd>
-                    </Column>
-                    <Column className={dashboardStyles.subcolumn} sm={2} lg={4}>
-                      <dt className={dashboardStyles.label}>Related libraries</dt>
-                      <dd className={dashboardStyles.meta}>
-                        {relatedLibraries.length > 0 ? relatedLibrariesLinks : '–'}
-                      </dd>
-                    </Column>
-                    <Column className={dashboardStyles.subcolumn} sm={2} lg={4}>
-                      <dt className={dashboardStyles.label}>Design files</dt>
-                      <dd className={dashboardStyles.meta}>
-                        <CarbonLink size="lg" href={designKitPath}>
-                          View compatible kits
-                        </CarbonLink>
-                      </dd>
-                    </Column>
-                  </Grid>
+      </Grid>
 
-                  <ButtonSet className={dashboardStyles['button-set']}>
-                    <Button
-                      className={dashboardStyles['dashboard-button']}
-                      onClick={() => {
-                        router.push(assetsPath)
-                      }}
-                    >
-                      View library assets
-                      <ArrowRight size={16} />
-                    </Button>{' '}
-                    <Button
-                      kind="tertiary"
-                      className={dashboardStyles['dashboard-button']}
-                      href={libraryData.content.externalDocsUrl}
-                    >
-                      View library docs
-                      <Launch size={16} />
-                    </Button>
-                  </ButtonSet>
-                </DashboardItem>
-              </Column>
-            </Dashboard>
-          </div>
-        </Column>
-        {libraryData.content.demoLinks && (
+      <ContentWrapper>
+        <Grid>
+          <Column sm={4} md={8} lg={8}>
+            <PageDescription className={styles['page-description']}>
+              {seo.description}
+            </PageDescription>
+            <AnchorLinks>
+              <AnchorLink>Dashboard</AnchorLink>
+              {libraryData.content.demoLinks && <AnchorLink>Demo links</AnchorLink>}
+              <AnchorLink>Resources</AnchorLink>
+            </AnchorLinks>
+          </Column>
+          <Column sm={4} md={8} lg={12}>
+            <div id="dashboard">
+              <Dashboard className={styles.dashboard}>
+                <Column className={dashboardStyles.column} sm={4}>
+                  <DashboardItem aspectRatio={{ sm: '2x1', md: '1x1', lg: '3x4', xlg: '1x1' }}>
+                    <dl>
+                      <dt className={dashboardStyles.label}>Version</dt>
+                      <dd className={dashboardStyles['label--large']}>{getVersion()}</dd>
+                    </dl>
+                    {MaintainerIcon && (
+                      <MaintainerIcon
+                        className={clsx(
+                          dashboardStyles['position-bottom-left'],
+                          styles['maintainer-icon']
+                        )}
+                        size={64}
+                      />
+                    )}
+                  </DashboardItem>
+                </Column>
+                <Column className={dashboardStyles.column} sm={4} lg={8}>
+                  <DashboardItem aspectRatio={{ sm: '3x4', md: '3x4', lg: 'none', xlg: 'none' }}>
+                    <Grid as="dl" className={dashboardStyles.subgrid}>
+                      <Column className={dashboardStyles.subcolumn} sm={2} lg={4}>
+                        <dt className={dashboardStyles.label}>Maintainer</dt>
+                        <dd className={dashboardStyles.meta}>
+                          {teams[libraryData.params.maintainer]?.name || 'Community'}
+                        </dd>
+                      </Column>
+                      <Column className={dashboardStyles.subcolumn} sm={2} lg={4}>
+                        <dt className={dashboardStyles.label}>License</dt>
+                        <dd className={dashboardStyles.meta}>{getAssetLicense(libraryData)}</dd>
+                      </Column>
+                      <Column className={dashboardStyles.subcolumn} sm={2} lg={4}>
+                        <dt className={dashboardStyles.label}>Related libraries</dt>
+                        <dd className={dashboardStyles.meta}>
+                          {relatedLibraries.length > 0 ? relatedLibrariesLinks : '–'}
+                        </dd>
+                      </Column>
+                      <Column className={dashboardStyles.subcolumn} sm={2} lg={4}>
+                        <dt className={dashboardStyles.label}>Design files</dt>
+                        <dd className={dashboardStyles.meta}>
+                          <CarbonLink size="lg" href={designKitPath}>
+                            View compatible kits
+                          </CarbonLink>
+                        </dd>
+                      </Column>
+                    </Grid>
+
+                    <ButtonSet className={dashboardStyles['button-set']}>
+                      <Button
+                        className={dashboardStyles['dashboard-button']}
+                        onClick={() => {
+                          router.push(assetsPath)
+                        }}
+                      >
+                        View library assets
+                        <ArrowRight size={16} />
+                      </Button>{' '}
+                      <Button
+                        kind="tertiary"
+                        className={dashboardStyles['dashboard-button']}
+                        href={libraryData.content.externalDocsUrl}
+                      >
+                        View library docs
+                        <Launch size={16} />
+                      </Button>
+                    </ButtonSet>
+                  </DashboardItem>
+                </Column>
+              </Dashboard>
+            </div>
+          </Column>
+          {libraryData.content.demoLinks && (
+            <Column sm={4} md={8} lg={8}>
+              <section>
+                <H2>Demo links</H2>
+                <DemoLinks links={libraryData?.content?.demoLinks || []} />
+              </section>
+            </Column>
+          )}
           <Column sm={4} md={8} lg={8}>
             <section>
-              <H2>Demo links</H2>
-              <DemoLinks links={libraryData?.content?.demoLinks || []} />
-            </section>
-          </Column>
-        )}
-        <Column sm={4} md={8} lg={8}>
-          <section>
-            <H2>Resources</H2>
+              <H2>Resources</H2>
 
-            <CardGroup>
-              {libraryData.content.inherits && libraryInheritanceCard()}
-              <Column sm={4} md={4} lg={4}>
-                <ResourceCard
-                  title={`${libraryData.params.org}/${libraryData.params.repo}`}
-                  subTitle={libraryData.params.host === 'github.com' ? 'GitHub' : 'IBM GitHub'}
-                  href={`https://${libraryData.params.host}/${libraryData.params.org}/${libraryData.params.repo}`}
-                >
-                  <Svg32Github />
-                </ResourceCard>
-              </Column>
-              {!libraryData.content.private && (
+              <CardGroup>
+                {libraryData.content.inherits && libraryInheritanceCard()}
                 <Column sm={4} md={4} lg={4}>
                   <ResourceCard
-                    title={libraryData.content.package}
-                    subTitle="Package"
-                    href={`https://npmjs.com/package/${libraryData.content.package}/v/${libraryData.content.version}`}
+                    title={`${libraryData.params.org}/${libraryData.params.repo}`}
+                    subTitle={libraryData.params.host === 'github.com' ? 'GitHub' : 'IBM GitHub'}
+                    href={`https://${libraryData.params.host}/${libraryData.params.org}/${libraryData.params.repo}`}
                   >
-                    <MdxIcon name="npm" />
+                    <Svg32Github />
                   </ResourceCard>
                 </Column>
-              )}
-            </CardGroup>
-          </section>
-        </Column>
-      </Grid>
+                {!libraryData.content.private && (
+                  <Column sm={4} md={4} lg={4}>
+                    <ResourceCard
+                      title={libraryData.content.package}
+                      subTitle="Package"
+                      href={`https://npmjs.com/package/${libraryData.content.package}/v/${libraryData.content.version}`}
+                    >
+                      <MdxIcon name="npm" />
+                    </ResourceCard>
+                  </Column>
+                )}
+              </CardGroup>
+            </section>
+          </Column>
+        </Grid>
+      </ContentWrapper>
     </>
   )
 }

--- a/services/web-app/pages/libraries/index.js
+++ b/services/web-app/pages/libraries/index.js
@@ -8,6 +8,7 @@ import { NextSeo } from 'next-seo'
 import PropTypes from 'prop-types'
 import { useContext, useEffect } from 'react'
 
+import ContentWrapper from '@/components/content-wrapper'
 import LibraryCatalog from '@/components/library-catalog/library-catalog'
 import PageDescription from '@/components/page-description/page-description'
 import PageHeader from '@/components/page-header'
@@ -41,12 +42,14 @@ const Libraries = ({ librariesData }) => {
     <>
       <NextSeo {...seo} />
       <PageHeader bgColor={pageHeader?.bgColor} title={seo.title} pictogram={pageHeader?.icon} />
-      <PageDescription className={styles['library-description']}>
-        Libraries are 1:1 with code packages. All coded components, elements, patterns, or functions
-        belong to a library and have a maintainer. Design kits with compatible code also live in
-        libraries.
-      </PageDescription>
-      <LibraryCatalog libraries={libraries} />
+      <ContentWrapper>
+        <PageDescription className={styles['library-description']}>
+          Libraries are 1:1 with code packages. All coded components, elements, patterns, or
+          functions belong to a library and have a maintainer. Design kits with compatible code also
+          live in libraries.
+        </PageDescription>
+        <LibraryCatalog libraries={libraries} />
+      </ContentWrapper>
     </>
   )
 }


### PR DESCRIPTION
closes #1215

New `ContentWrapper` component.
  - The intention is for any page content, mdx or otherwise to be wrapped in this component for consistent top spacing. 

This component was NOT added to any of the catalog pages for now, those pages have a different top spacing because the search bar is the first element. 


#### Testing / reviewing
Check mdx pages, js page and remote mdx pages, pages with/without tabs etc. 

http://localhost:3000/elements/icons/library
http://localhost:3000/libraries/carbon-react/latest/assets/accordion
http://localhost:3000/libraries/carbon-react/latest/assets/accordion/style
http://localhost:3000/libraries/carbon-react/latest/assets/accordion/usage
http://localhost:3000/libraries/carbon-react/latest/assets/accordion/accessibility
http://localhost:3000/about-carbon/releases
http://localhost:3000/about-carbon/articles
http://localhost:3000/elements/color/usage
http://localhost:3000/libraries/carbon-components-angular/latest
http://localhost:3000/libraries/carbon-components-angular/latest/design-kits
http://localhost:3000/libraries/carbon-components-angular/latest/pages/tutorial/step-2
