### PR TITLE
feat(web-app): have MdxPage take a source string instead of children

### DIFF
--- a/services/web-app/components/mdx-page/mdx-page.js
+++ b/services/web-app/components/mdx-page/mdx-page.js
@@ -4,9 +4,9 @@
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
-
 import Head from 'next/head'
 import { useRouter } from 'next/router'
+import { MDXRemote } from 'next-mdx-remote'
 import { NextSeo } from 'next-seo'
 import PropTypes from 'prop-types'
 import { useContext, useEffect } from 'react'
@@ -57,7 +57,7 @@ const createMdxErrorContent = ({ mdxError }) => {
   return <Component mdxError={mdxError} />
 }
 
-const createPageContent = ({ children, mdxError, warnings }) => {
+const createPageContent = ({ source, mdxError, warnings }) => {
   if (mdxError) {
     return createMdxErrorContent({ mdxError })
   }
@@ -65,7 +65,7 @@ const createPageContent = ({ children, mdxError, warnings }) => {
   return (
     <div className={styles['page-content']}>
       {warnings?.length > 0 && <WarningsRollup warnings={warnings} />}
-      {children}
+      <MDXRemote compiledSource={source} />
     </div>
   )
 }
@@ -84,15 +84,15 @@ const createSeo = ({ title, description, keywords }) => {
 }
 
 const MdxPage = ({
-  title,
   description,
   keywords,
-  tabs,
   mdxError,
-  warnings,
-  children,
   pageHeaderType,
-  seoTitle
+  seoTitle,
+  source,
+  tabs,
+  title,
+  warnings
 }) => {
   const { setPrimaryNavData } = useContext(LayoutContext)
   const router = useRouter()
@@ -118,16 +118,12 @@ const MdxPage = ({
         />
       )}
       {areTabsPresent && <PageTabs title={title} tabs={getTabData(tabs, baseSegment)} />}
-      {createPageContent({ children, mdxError, warnings })}
+      {createPageContent({ source, mdxError, warnings })}
     </>
   )
 }
 
 MdxPage.propTypes = {
-  /**
-   * The component representing the actual MDX to render. This should have already been sanitized.
-   */
-  children: PropTypes.node,
   /**
    * Description of the page, typically from frontmatter.
    */
@@ -152,6 +148,10 @@ MdxPage.propTypes = {
    * title to use for SEO
    */
   seoTitle: PropTypes.string,
+  /**
+   * **Compiled and sanitized** MDX source of the page as executable JS.
+   */
+  source: PropTypes.string,
   /**
    * Tabs to display on the page.
    */

--- a/services/web-app/pages/[...remote-mdx-path].js
+++ b/services/web-app/pages/[...remote-mdx-path].js
@@ -4,9 +4,6 @@
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
-
-import { MDXRemote } from 'next-mdx-remote'
-
 import MdxPage from '@/components/mdx-page/mdx-page'
 import withLoading from '@/components/with-loading'
 import { defaultFilePathPrefix, defaultParams, remotePages } from '@/data/remote-pages'
@@ -23,12 +20,11 @@ const RemoteMdxPage = ({ compiledSource, tabs, mdxError, warnings, pageHeaderTyp
       description={description}
       keywords={keywords}
       tabs={tabs}
+      source={compiledSource?.value}
       mdxError={mdxError}
       warnings={warnings}
       pageHeaderType={pageHeaderType}
-    >
-      {compiledSource && <MDXRemote compiledSource={compiledSource.value} />}
-    </MdxPage>
+    />
   )
 }
 

--- a/services/web-app/pages/libraries/[host]/[org]/[repo]/[library]/[ref]/pages/[...page].js
+++ b/services/web-app/pages/libraries/[host]/[org]/[repo]/[library]/[ref]/pages/[...page].js
@@ -4,7 +4,6 @@
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import { MDXRemote } from 'next-mdx-remote'
 import { NextSeo } from 'next-seo'
 import path from 'path'
 import { useContext, useEffect } from 'react'
@@ -41,12 +40,11 @@ const LibraryPage = ({ compiledSource, mdxError, warnings, navData, navTitle, li
         title={title}
         description={description}
         keywords={keywords}
+        source={compiledSource && compiledSource.value}
         mdxError={mdxError}
         warnings={warnings}
         pageHeaderType="library"
-      >
-        {compiledSource && <MDXRemote compiledSource={compiledSource.value} />}
-      </MdxPage>
+      />
     </>
   )
 }

--- a/services/web-app/pages/samples/remote-mdx-test.js
+++ b/services/web-app/pages/samples/remote-mdx-test.js
@@ -4,8 +4,6 @@
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import { MDXRemote } from 'next-mdx-remote'
-
 import MdxPage from '@/components/mdx-page/mdx-page'
 import { getRemoteMdxSource } from '@/lib/github'
 import { processMdxSource } from '@/utils/mdx'
@@ -21,11 +19,10 @@ const RemoteMdxTest = ({ compiledSource, tabs, mdxError, warnings }) => {
       keywords={keywords}
       tabs={tabs}
       mdxError={mdxError}
+      source={compiledSource?.value}
       warnings={warnings}
       pageHeaderType={pageHeaderType}
-    >
-      {compiledSource && <MDXRemote compiledSource={compiledSource.value} />}
-    </MdxPage>
+    />
   )
 }
 

--- a/services/web-app/utils/mdx.js
+++ b/services/web-app/utils/mdx.js
@@ -97,12 +97,11 @@ export async function processMdxSource(mdxSource, url) {
 }
 
 /**
- * Retrieves the remote mdx source content, processes it
- * and converts it into an object containing HTML value
+ * Retrieves the remote mdx source content, processes it and converts it into an object containing
+ * executable React JS.
  * @param {import('@/typedefs').Params} params
  * @param {string} url
- * @returns {Promise<import('@/typedefs').RemoteMdxSource>}
- * mdxSource or empty object
+ * @returns {Promise<import('@/typedefs').RemoteMdxSource>} mdxSource or empty object
  */
 export async function getProcessedMdxSource(params, url) {
   let processedMdx = {}


### PR DESCRIPTION
- This reduces the number of places where MDXRemote needs to be used
- MdxPage now handles this for "remote-mdx-path" and "page"
- Fix docs in mdx utils