### PR TITLE
fix: indexed path for style strategies page

### DIFF
--- a/services/web-app/components/mdx-page/errors/content-not-found-exception-content.js
+++ b/services/web-app/components/mdx-page/errors/content-not-found-exception-content.js
@@ -11,8 +11,8 @@ const ContentNotFoundExceptionContent = ({ mdxError }) => {
   return (
     <FullPageError
       title="The page you are looking for cannot be found."
-      subtitle="Supplied Github route does not exist. Update to a valid route."
-      link="See common errors for further information on valid urls"
+      subtitle="Supplied GitHub route does not exist. Update to a valid route."
+      link="See common errors for further information on valid URLs."
       href="/common-mdx-errors#the-page-you're-looking-for-cannot-be-found"
     >
       <p>{mdxError.message}</p>

--- a/services/web-app/config/redirects.mjs
+++ b/services/web-app/config/redirects.mjs
@@ -190,6 +190,7 @@ const platformRedirects = [
   ['/elements/spacing', '/elements/spacing/overview'],
   ['/elements/themes', '/elements/themes/overview'],
   ['/elements/typography', '/elements/typography/overview'],
+  ['/elements/typography/styling-strategies', '/elements/typography/style-strategies'],
   ['/guidelines', '/guidelines/accessibility/overview'],
   ['/guidelines/accessibility', '/guidelines/accessibility/overview'],
   ['/guidelines/content', '/guidelines/content/overview'],

--- a/services/web-app/data/remote-pages.js
+++ b/services/web-app/data/remote-pages.js
@@ -121,7 +121,14 @@ export const remotePages = {
     }
   },
   'elements/typography/styling-strategies': {
-    filePath: '/src/pages/guidelines/typography/styling-strategies.mdx'
+    filePath: '/src/pages/guidelines/typography/styling-strategies.mdx',
+    params: {
+      host: 'github.com',
+      org: 'carbon-design-system',
+      repo: 'carbon-website',
+      library: 'carbon-website',
+      ref: 'carbon-platform'
+    }
   },
   'elements/typography/type-sets': {
     filePath: '/src/pages/guidelines/typography/type-sets.mdx',

--- a/services/web-app/data/remote-pages.js
+++ b/services/web-app/data/remote-pages.js
@@ -120,15 +120,8 @@ export const remotePages = {
       ref: 'carbon-platform'
     }
   },
-  'elements/typography/styling-strategies': {
-    filePath: '/src/pages/guidelines/typography/styling-strategies.mdx',
-    params: {
-      host: 'github.com',
-      org: 'carbon-design-system',
-      repo: 'carbon-website',
-      library: 'carbon-website',
-      ref: 'carbon-platform'
-    }
+  'elements/typography/style-strategies': {
+    filePath: '/src/pages/guidelines/typography/style-strategies.mdx'
   },
   'elements/typography/type-sets': {
     filePath: '/src/pages/guidelines/typography/type-sets.mdx',

--- a/services/web-app/pages/common-mdx-errors/index.js
+++ b/services/web-app/pages/common-mdx-errors/index.js
@@ -214,8 +214,8 @@ const CommonMdxErrors = () => {
         <div className={styles['error-container']}>
           <FullPageError
             title="The page you are looking for cannot be found."
-            subtitle="Supplied Github route does not exist. Update to a valid route."
-            link="See common errors for further information on valid urls"
+            subtitle="Supplied GitHub route does not exist. Update to a valid route."
+            link="See common errors for further information on valid URLs."
             href="/common-mdx-errors#the-page-you're-looking-for-cannot-be-found"
           >
             <CodeSnippet type="inline">{'./anything.mdx'}</CodeSnippet>


### PR DESCRIPTION
Found during an audit of remote MDX, this page is broken: https://next.carbondesignsystem.com/elements/typography/styling-strategies

<img width="1336" alt="image" src="https://user-images.githubusercontent.com/1691245/198082948-4227e601-f9c1-418c-90bf-c4a8ae27ccd5.png">

#### Changelog

**New**

- N/A

**Changed**

- Branch of `carbon-website` used to index the Styling strategies page
- "GitHub" and "URLs" capitalization in the MDX errors

**Removed**

- N/A

#### Testing / reviewing

<img width="1336" alt="image" src="https://user-images.githubusercontent.com/1691245/198083225-4268088e-938d-4bed-8853-82dd10acc8a3.png">