### PR TITLE
fix: use akamai plex CDN so we have fi ligatures

### DIFF
--- a/services/web-app/styles/vendor/_carbon.scss
+++ b/services/web-app/styles/vendor/_carbon.scss
@@ -5,5 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+@use '@carbon/react/scss/config' with (
+  $use-akamai-cdn: true
+);
 @use '@carbon/react';
 @use '@carbon-platform/mdx-components/styles';


### PR DESCRIPTION
Closes #448

Per https://github.com/carbon-design-system/carbon/issues/11175#issuecomment-1163067469, this PR uses the new Plex version through the `$use-akamai-cdn` Sass config variable.

#### Changelog

**New**

- Uses Akamai server for the Plex CDN

**Changed**

- N/A

**Removed**

- N/A

#### Testing / reviewing

Plex should look as it did before, but you'll now see "fi" ligatures like in our hero heading.
<img width="1207" alt="image" src="https://user-images.githubusercontent.com/1691245/199060928-db827da1-ba14-47d6-b95c-90d44e856efb.png">
