### PR TITLE
fix(mdx-components): add withPrefix util to preview class

### DIFF
--- a/packages/mdx-components/src/main/preview/_preview.scss
+++ b/packages/mdx-components/src/main/preview/_preview.scss
@@ -9,7 +9,7 @@
 @use '@carbon/react/scss/spacing' as spacing;
 @use '../utils' as *;
 
-.preview {
+.#{with-prefix('preview')} {
   width: 100%;
   border: 1px solid theme.$border-subtle;
   margin-top: spacing.$spacing-07;


### PR DESCRIPTION
Closes #1509 

#### Changelog

**Changed**

- packages/mdx-components/src/main/preview/_preview.scss: add `withPrefix` util

#### Testing / reviewing

1. do an npm install
2. run mdx-components storybook and verify http://localhost:6006/?path=/docs/components-preview--default
3. run web-app and verify http://localhost:3000/libraries/carbon-components-angular/latest/pages/tutorial/step-2
