### PR TITLE
refactor(web-app): sort-by-dropdown component

### DIFF
--- a/services/web-app/components/catalog-sort/catalog-sort.js
+++ b/services/web-app/components/catalog-sort/catalog-sort.js
@@ -4,12 +4,13 @@
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import { Column, Dropdown, Grid, IconButton } from '@carbon/react'
+import { Column, Grid, IconButton } from '@carbon/react'
 import { Grid as GridIcon, List as ListIcon } from '@carbon/react/icons'
 import clsx from 'clsx'
 import PropTypes from 'prop-types'
 import { useCallback, useEffect, useRef, useState } from 'react'
 
+import SortByDropdown from '@/components/sort-by-dropdown'
 import { GRID_VIEW, LIST_VIEW } from '@/data/view'
 import useEventListener from '@/utils/use-event-listener'
 
@@ -48,19 +49,11 @@ const CatalogSort = ({
     >
       <Grid className={styles.grid} narrow>
         <Column className={styles.column} sm={4} md={8} lg={4}>
-          <Dropdown
-            id="catalog-sort"
-            className={styles.dropdown}
-            initialSelectedItem={sortOptions.find((item) => item.id === sortId)}
-            items={sortOptions}
-            itemToString={(item) => (item ? item.text : '')}
-            onChange={({ selectedItem }) => {
-              onSort(selectedItem.id)
-            }}
-            type="inline"
-            titleText="Sort by:"
-            label={sortOptions[defaultSortIndex].text}
-            size="lg"
+          <SortByDropdown
+            onSort={onSort}
+            sortOptions={sortOptions}
+            defaultSortIndex={defaultSortIndex}
+            sortId={sortId}
           />
         </Column>
         <Column className={`${styles.column} ${styles['column--switcher']}`} lg={8}>

--- a/services/web-app/components/catalog-sort/catalog-sort.module.scss
+++ b/services/web-app/components/catalog-sort/catalog-sort.module.scss
@@ -52,39 +52,6 @@
   }
 }
 
-.dropdown {
-  // override carbon display, grid-gap
-  position: relative;
-  display: flex;
-  width: 100%;
-  grid-gap: 0;
-
-  // overide carbon color
-  :global(.cds--label) {
-    color: theme.$text-primary;
-    @include breakpoint.breakpoint(md) {
-      padding-left: 0;
-    }
-  }
-
-  // overide carbon position, flex-grow
-  :global(.cds--dropdown) {
-    position: static;
-    flex-grow: 1;
-    border: none;
-  }
-
-  // overide carbon max-width
-  :global(.cds--list-box__field),
-  :global(.cds--list-box__menu) {
-    max-width: none;
-  }
-
-  @include breakpoint.breakpoint(md) {
-    padding-left: spacing.$spacing-05;
-  }
-}
-
 .button {
   // override carbon because `lg` isn't supported
   width: convert.rem(48px);

--- a/services/web-app/components/sort-by-dropdown/index.js
+++ b/services/web-app/components/sort-by-dropdown/index.js
@@ -1,0 +1,7 @@
+/*
+ * Copyright IBM Corp. 2022, 2022
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+export { default } from './sort-by-dropdown'

--- a/services/web-app/components/sort-by-dropdown/sort-by-dropdown.js
+++ b/services/web-app/components/sort-by-dropdown/sort-by-dropdown.js
@@ -1,0 +1,62 @@
+/*
+ * Copyright IBM Corp. 2021, 2022
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import { Dropdown } from '@carbon/react'
+import PropTypes from 'prop-types'
+
+import styles from './sort-by-dropdown.module.scss'
+
+const SortByDropdown = ({ defaultSortIndex = 0, onSort, sortId, sortOptions = [] }) => {
+  return (
+    <Dropdown
+      id="sort-by-dropdown"
+      className={styles.dropdown}
+      initialSelectedItem={sortOptions.find((item) => item.id === sortId)}
+      items={sortOptions}
+      itemToString={(item) => (item ? item.text : '')}
+      onChange={({ selectedItem }) => {
+        onSort(selectedItem.id)
+      }}
+      type="inline"
+      titleText="Sort by:"
+      label={sortOptions[defaultSortIndex].text}
+      size="lg"
+    />
+  )
+}
+
+SortByDropdown.defaultProps = {
+  defaultSortIndex: 0,
+  sortOptions: []
+}
+
+SortByDropdown.propTypes = {
+  /**
+   * Indicates array position of default sort strategy in sortOptions array
+   */
+  defaultSortIndex: PropTypes.number,
+  /**
+   * (sortId) => void
+   * Function to call when new sort option is selected.
+   * Should update sortId passed to props
+   */
+  onSort: PropTypes.func.isRequired,
+  /**
+   * Id of currently selected sort option
+   */
+  sortId: PropTypes.string.isRequired,
+  /**
+   * Array of object options the list of items can be sorted by
+   */
+  sortOptions: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string,
+      text: PropTypes.string
+    })
+  ).isRequired
+}
+
+export default SortByDropdown

--- a/services/web-app/components/sort-by-dropdown/sort-by-dropdown.module.scss
+++ b/services/web-app/components/sort-by-dropdown/sort-by-dropdown.module.scss
@@ -1,0 +1,41 @@
+/*
+ * Copyright IBM Corp. 2022, 2022
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+@use '@carbon/react/scss/breakpoint' as breakpoint;
+@use '@carbon/react/scss/spacing' as spacing;
+@use '@carbon/react/scss/theme' as theme;
+
+.dropdown {
+  // override carbon display, grid-gap
+  position: relative;
+  display: flex;
+  width: 100%;
+  grid-gap: 0;
+
+  // overide carbon color
+  :global(.cds--label) {
+    padding-left: spacing.$spacing-05;
+    color: theme.$text-primary;
+  }
+
+  // overide carbon position, flex-grow
+  :global(.cds--dropdown) {
+    position: static;
+    flex-grow: 1;
+    border: none;
+  }
+
+  // overide carbon max-width
+  :global(.cds--list-box__field),
+  :global(.cds--list-box__menu) {
+    max-width: none;
+
+    @include breakpoint.breakpoint('lg') {
+      min-width: 0;
+    }
+  }
+}

--- a/services/web-app/pages/libraries/[host]/[org]/[repo]/[library]/[ref]/assets/index.js
+++ b/services/web-app/pages/libraries/[host]/[org]/[repo]/[library]/[ref]/assets/index.js
@@ -7,7 +7,6 @@
 import {
   Column,
   DataTable,
-  Dropdown,
   Grid,
   Table,
   TableBody,
@@ -27,6 +26,7 @@ import { useContext, useEffect, useState } from 'react'
 import AssetCatalogItemMeta from '@/components/asset-catalog-item/asset-catalog-item-meta'
 import ContentWrapper from '@/components/content-wrapper'
 import PageHeader from '@/components/page-header'
+import SortByDropdown from '@/components/sort-by-dropdown'
 import TypeTag from '@/components/type-tag'
 import withLoading from '@/components/with-loading'
 import { assetsNavData } from '@/data/nav-data'
@@ -149,19 +149,11 @@ const LibrayAssets = ({ libraryData, params, navData }) => {
             </Grid>
             <Grid condensed={!isLg} narrow={isLg}>
               <Column className={styles['sort-column']} sm={4} md={4} lg={4}>
-                <Dropdown
-                  id="catalog-sort"
-                  className={styles.dropdown}
-                  initialSelectedItem={sortItems.find((item) => item.id === sort)}
-                  items={sortItems}
-                  itemToString={(item) => (item ? item.text : '')}
-                  onChange={({ selectedItem }) => {
-                    onSort(selectedItem.id)
-                  }}
-                  type="inline"
-                  titleText="Sort by:"
-                  label="A–Z"
-                  size="lg"
+                <SortByDropdown
+                  onSort={onSort}
+                  sortOptions={sortItems}
+                  defaultSortIndex={0}
+                  sortId={sort}
                 />
               </Column>
             </Grid>

--- a/services/web-app/pages/libraries/[host]/[org]/[repo]/[library]/[ref]/assets/index.module.scss
+++ b/services/web-app/pages/libraries/[host]/[org]/[repo]/[library]/[ref]/assets/index.module.scss
@@ -53,33 +53,6 @@
   }
 }
 
-.dropdown {
-  // override carbon display, grid-gap
-  position: relative;
-  display: flex;
-  width: 100%;
-
-  grid-gap: 0;
-
-  // overide carbon color
-  :global(.cds--label) {
-    color: theme.$text-primary;
-  }
-
-  // overide carbon position, flex-grow
-  :global(.cds--dropdown) {
-    z-index: 1;
-    flex-grow: 1;
-    border: none;
-  }
-
-  // overide carbon max-width
-  :global(.cds--list-box__field),
-  :global(.cds--list-box__menu) {
-    max-width: none;
-  }
-}
-
 .tag {
   display: inline;
 }


### PR DESCRIPTION
Closes #1511 

* Put both "sort by" options from library assets and catalog into a `SortByDropdown` component so we don't have to maintain styles across two places. 
* Fix for sort by misalignment
* Fix for dropdown options width issue

#### Changelog

**New**

-`SortByDropdown` component

**Changed**

- services/web-app/components/catalog-sort/catalog-sort.js: use `SortByDropdown` instead of custom dropdown
- services/web-app/pages/libraries/[host]/[org]/[repo]/[library]/[ref]/assets/index.js: use `SortByDropdown` instead of custom dropdown

**Removed**

- services/web-app/components/catalog-sort/catalog-sort.module.scss: remove `dropdown` styles
- services/web-app/pages/libraries/[host]/[org]/[repo]/[library]/[ref]/assets/index.module.scss: remove `dropdown` styles

#### Testing / reviewing

* Asses `sort by` alignment and dropdown options width across all breakpoints
* Ensure sort still works 

- http://localhost:3000/libraries/carbon-react/latest/assets 
- http://localhost:3000/assets/components
