### PR TITLE
fix(mdx-components): add bottom margin to article card

### DIFF
--- a/packages/mdx-components/src/main/article-card/_article-card.scss
+++ b/packages/mdx-components/src/main/article-card/_article-card.scss
@@ -28,6 +28,7 @@
     position: relative;
     height: 100%;
     padding: 0;
+    margin-bottom: spacing.$spacing-06;
     background: transparent;
     text-decoration: none;
 


### PR DESCRIPTION
Closes #1512

Adds margin bottom to article card tile

#### Testing / reviewing

Compare article cards at different breakpoints:
http://localhost:3000/about-carbon/articles
https://carbondesignsystem.com/whats-happening/news-and-articles/
