### PR TITLE
fix: clean up copy

### DIFF
--- a/services/web-app/pages/about-carbon/how-carbon-works.mdx
+++ b/services/web-app/pages/about-carbon/how-carbon-works.mdx
@@ -17,16 +17,16 @@ import { section } from './how-carbon-works.module.scss'
 <AnchorLinks>
   <AnchorLink>The Carbon ecosystem</AnchorLink>
   <AnchorLink>Key terms</AnchorLink>
-  <AnchorLink>Carbon maintainers</AnchorLink>
+  <AnchorLink>Maintainers</AnchorLink>
 </AnchorLinks>
 
 ## The Carbon ecosystem
 
-Carbon is a system of systems. At the epicenter lies the `core system`, with elements, assets, code,
+Carbon is a system of systems. At the epicenter lies the core system, with elements, assets, code,
 design kits, and guidelines intended as a base for the widest variety of situations. These assets
 are open source and can be easily extended or adapted.
 
-Teams at IBM also create `local systems` that depend on and extend the core system for specific use
+Teams at IBM also create local systems that depend on and extend the core system for specific use
 cases. For example, [Carbon for IBM.com](https://www.ibm.com/standards/carbon/) is a local system
 that specializes in an editorial experience, whereas
 [Carbon for IBM Products](https://pages.github.ibm.com/cdai-design/pal/) provides assets and
@@ -34,8 +34,8 @@ guidance specific to the product experience.
 
 Some local systems are open source while others require IBM employee authentication to view.
 
-It is recommended that you start with the core system and whichever local systems are most relevant
-to your team. Catalogs for [components](/assets/components), [patterns](/assets/patterns),
+It is recommended that you start with the core system and whichever local system is most relevant to
+your team. Catalogs for [components](/assets/components), [patterns](/assets/patterns),
 [functions](/assets/functions), and [templates](/assets/templates) allow you to explore everything
 Carbon has to offer, with filters to find exactly what you need.
 
@@ -67,25 +67,26 @@ as color tokens, type tokens, spacing tokens, the grid, and more.
 **Guidelines** provide direction on critical topics such as accessibility and content and ensure
 consistent user experiences that meet IBM's standards.
 
-**Assets** include re–usable resources such as components, patterns, functions, and templates. Each
-asset has code, designs, and usage guidance.
+**Assets** are re–usable resources such as components, patterns, functions, and templates. Assets
+often have usage and accessibililty guidance, as well as styling specifications and code.
 
-**Design kits** are libraries from Sketch and Figma—and other tools such as Adobe XD and Invision.
-They contain components and elements as well as wireframes and guidance to aid designers.
+**Design kits** contain elements, guidelines, user interface components and patterns, and wireframes
+for various design tools as the design counterpart to coded assets.
 
-**Libraries** are 1:1 with code packages. All coded assets belong to a library and have a
-maintainer. Design kits with compatible code also live in libraries.
+**Libraries** are the means to contribute, install, and use one or many assets. All coded assets
+belong to a library. Most all libraries are published as code packages. Libraries have compatible
+design kits.
 
-## Carbon maintainers
+## Maintainers
 
-Carbon core and local systems have `maintainers` that administer governance over content and
-resource visibility. Each resource cites a maintaining team if an IBM team primarily maintains the
-resource. If an individual or informal group is responsible for a resource, it will be listed as
-community maintained.
+Carbon systems have maintainers that administer governance over content and resource visibility.
+Design kits and libraries cite a maintaining team if an IBM team primarily maintains the resource.
+If an individual or informal group is responsible for a resource, it will be listed as community
+maintained.
 
-Maintainers can control content and resource visibility through a metadata file that follows a clear
-`schema`. The [schema](/contributing/schema) helps us document each resource in a standardized way
-and enables everything to be indexed by Carbon’s new underlying platform.
+Maintainers can control content and resource visibility through a metadata file that follows a
+[schema](/contributing/schema). The schema helps us document each resource in a standardized way and
+enables everything to be indexed by Carbon’s underlying platform.
 
-The Carbon platform and website is maintained by the Carbon team. Progress on the new platform can
-be found in our [roadmap](/about-carbon/platform-roadmap).
+The Carbon platform and website is maintained by the Carbon Platform Squad. Progress on the new
+platform can be found in the [roadmap](/about-carbon/platform-roadmap).

--- a/services/web-app/pages/contributing/schema.mdx
+++ b/services/web-app/pages/contributing/schema.mdx
@@ -118,9 +118,12 @@ designKits:
 
 ## Library schema
 
-Libraries are the means to contribute, install, and use one or many assets in products and digital
-experiences. To index your library with Carbon, create a `carbon.yml` metadata file and place it in
-the same directory as your library's `package.json` file.
+Libraries are the means to contribute, install, and use one or many assets. All coded assets belong
+to a library. Most all libraries are published as code packages. Libraries have compatible design
+kits.
+
+To index your library with Carbon, create a `carbon.yml` metadata file and place it in the same
+directory as your library's `package.json` file.
 
 <AnchorLinks small>
 
@@ -211,7 +214,8 @@ asset key to override the inherited default.
 
 ## Asset schema
 
-Assets are reusable units of work that are used in products and digital experiences. Every asset
+Assets are re–usable resources such as components, patterns, functions, and templates. Assets often
+have usage and accessibililty guidance, as well as styling specifications and code. Every asset
 belongs to a library.
 
 <AnchorLinks small>
@@ -286,12 +290,12 @@ assets:
 Asset type is used for primary categorization in asset catalogs. The `type` key can have the
 following values:
 
-| Type        | Description                                                                                                                                                                                            |
-| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `component` | Building blocks that have been designed and coded to solve a specific user interface problem.                                                                                                          |
-| `function`  | Code that performs a single action or actions and has no user interface.                                                                                                                               |
-| `pattern`   | Best practice solution for how a user achieves a goal through reusable combinations of components and content with sequences and flows which are too complex to be encapsulated in a single component. |
-| `template`  | Layout example that specifies patterns and component order and placement to compose a specific view.                                                                                                   |
+| Type        | Description                                                                                   |
+| ----------- | --------------------------------------------------------------------------------------------- |
+| `component` | Building blocks that have been designed and coded to solve a specific user interface problem. |
+| `function`  | Coded logic that performs one or many actions and has no user interface.                      |
+| `pattern`   | Reusable combinations of components and content with sequences and flows.                     |
+| `template`  | Order and placement of patterns and components to compose a specific view.                    |
 
 ### Component tags
 

--- a/services/web-app/pages/index.js
+++ b/services/web-app/pages/index.js
@@ -108,9 +108,8 @@ const PageContent = () => {
 
       <H2>Search asset catalogs</H2>
       <P>
-        Asset catalogs allow you to search across all open and inner source resources and apply
-        complex filters for any scenario — so that you can apply other teams’ knowledge to your own
-        work.
+        Asset catalogs allow you to search across all open-source Carbon resources and apply complex
+        filters for any scenario — so that you can apply other teams’ knowledge to your own work.
       </P>
 
       <Dashboard>
@@ -122,8 +121,8 @@ const PageContent = () => {
             <dl>
               <dt className={styles['dashboard-label']}>Components</dt>
               <dd className={styles['dashboard-content']}>
-                Building blocks (such as buttons, links, and dropdown menus) that are pre-built and
-                ready to use when creating new experiences.
+                Building blocks that have been designed and coded to solve a specific user interface
+                problem.
               </dd>
             </dl>
             <Svg64Components className={styles['dashboard-icon']} />
@@ -159,7 +158,7 @@ const PageContent = () => {
             <dl>
               <dt className={styles['dashboard-label']}>Functions</dt>
               <dd className={styles['dashboard-content']}>
-                Code that performs a single action and has no user interface.
+                Coded logic that performs one or many actions and has no user interface.
               </dd>
             </dl>
             <Svg64Functions className={styles['dashboard-icon']} />
@@ -178,8 +177,7 @@ const PageContent = () => {
             <dl>
               <dt className={styles['dashboard-label']}>Templates</dt>
               <dd className={styles['dashboard-content']}>
-                Templates specify order and placement of patterns and components for a given
-                scenario.
+                Order and placement of patterns and components to compose a specific view.
               </dd>
             </dl>
             <Svg64Templates className={styles['dashboard-icon']} />
@@ -202,7 +200,7 @@ const PageContent = () => {
 
       <FeatureCard
         href="/libraries/carbon-react"
-        title="Carbon React library"
+        title="Carbon React"
         description="Build user interfaces with core components using Carbon’s primary library."
       >
         <ArtDirection>
@@ -226,7 +224,7 @@ const PageContent = () => {
       <Divider />
 
       <P className={styles['intro-paragraph']}>
-        By standardizing and surfacing our assets, the new site helps makers find assets that{' '}
+        By standardizing and surfacing our assets, the new site helps creators find assets that{' '}
         <mark>comply</mark> with platform requirements, are <mark>convenient</mark> to implement,
         and are <mark>consistent</mark> with design patterns across the company.
         <br />↓
@@ -245,7 +243,7 @@ const PageContent = () => {
             <P large>
               <strong>For designers and developers:</strong>
               <br />A unified discovery experience helps designers and developers find and access
-              components, patterns, and functions across all IBM teams.
+              components, patterns, functions, and templates across all IBM teams.
             </P>
           </Column>
         </Grid>
@@ -262,8 +260,8 @@ const PageContent = () => {
           <Column sm={4} md={4} lg={7}>
             <P large>
               <strong>For contributors and maintainers:</strong>
-              <br />A common schema helps PAL maintainers more easily manage their assets, keep
-              content fresh in a live index, and add version control to their libraries.
+              <br />A common schema helps maintainers more easily manage their assets, keep content
+              fresh in a live index, and add version control to their libraries.
             </P>
           </Column>
         </Grid>
@@ -272,9 +270,9 @@ const PageContent = () => {
 
       <H2>How PAL teams can prepare</H2>
       <P>
-        Ensure your components, patterns, and functions are indexed in our unified asset discovery
-        experience. To help you get started, our team will reach out to document your library’s
-        metadata in the structured format we have provided.
+        Ensure your Pattern and Asset Library (PAL) components and patterns are indexed in our
+        unified asset discovery experience. To help you get started, our team will reach out to
+        document your library’s metadata in the structured format we have provided.
       </P>
       <Grid>
         <Column sm={4} md={8} lg={8}>

--- a/services/web-app/pages/libraries/[host]/[org]/[repo]/[library]/[ref]/design-kits.js
+++ b/services/web-app/pages/libraries/[host]/[org]/[repo]/[library]/[ref]/design-kits.js
@@ -17,7 +17,6 @@ import {
   ResourceCard
 } from '@carbon-platform/mdx-components'
 import groupBy from 'lodash/groupBy'
-import Link from 'next/link'
 import { NextSeo } from 'next-seo'
 import { useContext, useEffect } from 'react'
 
@@ -90,13 +89,8 @@ const DesignKits = ({ libraryData, navData }) => {
             {libraryData.content.designKits && (
               <>
                 <PageDescription>
-                  The following design kits are compatible with the {name} library. If you are new
-                  to Carbon, check out the{' '}
-                  <Link href="/designing/get-started" passHref>
-                    <CarbonLink>design guidance</CarbonLink>
-                  </Link>{' '}
-                  to get started. You can also view all design kits in the{' '}
-                  <CarbonLink href="/design-kits">catalog</CarbonLink>.
+                  The following design kits are compatible with the {name} library. You can also
+                  view all design kits in the <CarbonLink href="/design-kits">catalog</CarbonLink>.
                 </PageDescription>
                 {filteredDesignTools.length > 2 && (
                   <AnchorLinks>


### PR DESCRIPTION
Home page, how Carbon works, and the schema page content changes.

#### Changelog

**New**

- N/A

**Changed**

Home page:

- Removed mention of inner source, because we don't index IBM internal resources yet
- Updated descriptions for components, functions, and templates and made them consistent with the schema page descriptions. It was odd how only the component description had an `e.g.` This also made the description lengths more consistent to prevent widows at common breakpoints.
- Remove unnecessary use of "library" in the first feature card, because the second feature card didn't include "library"
- Changed "makers" to "creators" to align with IBM's "Let's Create"
- Made sure our use of asset type lists was consistent
- Spelled out "Pattern and Asset Library" near the first place that we use the "PAL" acronym

Schema page:

- Updated library and asset descriptions
- Updated asset type descriptions to match what's used in the home page, and so the lengths are more consistent

How Carbon works page:

- Made anchor link headings more consistent (we don't need "Carbon" in every heading)
- Removed code formatting of emphasized words. We don't need to emphasize words.
- Updated definitions to match the above two pages.
- Added more specificity to who maintains the platform, as we specifically state that the system squad maintains a bunch of the libraries.

**Removed**

- N/A

#### Testing / reviewing

Run locally to see the updated pages.
