### PR TITLE
fix(web-app): chevron up on treeview expanded

### DIFF
--- a/services/web-app/components/nav-tree/nav-tree.module.scss
+++ b/services/web-app/components/nav-tree/nav-tree.module.scss
@@ -110,6 +110,10 @@
 
   // parent treenode open
   :global(.cds--tree-node[aria-expanded='true']) {
+    :global(.cds--tree-parent-node__toggle::after) {
+      transform: rotate(180deg);
+    }
+
     color: theme.$text-primary;
   }
 


### PR DESCRIPTION
Closes #1527 

Rotates treeview icon 180 deg on treenode expanded so chevron points up

#### Changelog

**Changed**

- services/web-app/components/nav-tree/nav-tree.module.scss: add rule


#### Testing / reviewing

test side nav open/close anywhere within the app, everything else should work as expected
