### PR TITLE
fix(web-app): add specifity to chevron up nav tree class

### DIFF
--- a/services/web-app/components/nav-tree/nav-tree.module.scss
+++ b/services/web-app/components/nav-tree/nav-tree.module.scss
@@ -110,7 +110,7 @@
 
   // parent treenode open
   :global(.cds--tree-node[aria-expanded='true']) {
-    :global(.cds--tree-parent-node__toggle::after) {
+    > * > :global(.cds--tree-parent-node__toggle::after) {
       transform: rotate(180deg);
     }
 


### PR DESCRIPTION
Think I got it right this time :) (but also please test this 🤣 🙏 )

Reference: https://github.com/carbon-design-system/carbon-platform/commit/56a0e338ca1258bb650b11e6c82469d6d55fe660#diff-f41da72055179eda1ed546caf5c9619111a0e86b21203e7ca4f5f01bf4e4ed2bL97

#### Changelog

**Changed**

- services/web-app/components/nav-tree/nav-tree.module.scss: made class more specific so it doesn't target nested menu items

#### Testing / reviewing

Run web-app and test side nav with nested items, make sure only the chevron of the menu item that you clicked on changes orientation on open/close
