### PR TITLE
fix(web-app): add spacer columns to catalog multiselect filter

### DIFF
--- a/services/web-app/components/catalog-multislect-filter/catalog-multiselect-filter.js
+++ b/services/web-app/components/catalog-multislect-filter/catalog-multiselect-filter.js
@@ -62,6 +62,19 @@ const CatalogMultiselectFilter = ({
     return sum + filter[item].length
   }, 0)
 
+  const addSpacerColumns = () => {
+    if (Object.keys(availableFilters).length % columns > 0) {
+      const spacerCols = []
+      for (let i = 0; i < columns - (Object.keys(availableFilters).length % columns); i++) {
+        spacerCols.push(
+          <Column className={styles.column} key={i + Object.keys(availableFilters).length} sm={1} />
+        )
+      }
+      return spacerCols
+    }
+    return null
+  }
+
   return (
     <Popover
       align="bottom-right"
@@ -144,6 +157,7 @@ const CatalogMultiselectFilter = ({
                   </ul>
                 </Column>
               ))}
+              {addSpacerColumns()}
             </Grid>
           </Column>
         </div>

--- a/services/web-app/components/catalog-multislect-filter/catalog-multiselect-filter.js
+++ b/services/web-app/components/catalog-multislect-filter/catalog-multiselect-filter.js
@@ -63,11 +63,12 @@ const CatalogMultiselectFilter = ({
   }, 0)
 
   const addSpacerColumns = () => {
-    if (Object.keys(availableFilters).length % columns > 0) {
+    const availableFiltersLength = Object.keys(availableFilters).length
+    if (availableFiltersLength % columns > 0) {
       const spacerCols = []
-      for (let i = 0; i < columns - (Object.keys(availableFilters).length % columns); i++) {
+      for (let i = 0; i < columns - (availableFiltersLength % columns); i++) {
         spacerCols.push(
-          <Column className={styles.column} key={i + Object.keys(availableFilters).length} sm={1} />
+          <Column className={styles.column} key={i + availableFiltersLength} sm={1} />
         )
       }
       return spacerCols


### PR DESCRIPTION
Closes #1153 

Add necessary spacer columns (if any) to multiselect filter display so that the border shows up across the whole line.

#### Changelog

**Changed**

- services/web-app/components/catalog-multislect-filter/catalog-multiselect-filter.js: add and use `addSpacerColumns` function

#### Testing / reviewing

Test multiselect filter across different breakpoints, should behave the same except visually all line borders should go all the way down

http://localhost:3000/assets/patterns
http://localhost:3000/assets/components
http://localhost:3000/assets/functions
http://localhost:3000/assets/templates
