### PR TITLE
docs: update copyright comments to 2023

### DIFF
--- a/.commitlintrc.js
+++ b/.commitlintrc.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/.copyright.js
+++ b/.copyright.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. <%= YEAR %>, 2022
+ * Copyright IBM Corp. <%= YEAR %>, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,5 @@
 #
-# Copyright IBM Corp. 2022, 2022
+# Copyright IBM Corp. 2022, 2023
 #
 # This source code is licensed under the Apache-2.0 license found in the
 # LICENSE file in the root directory of this source tree.

--- a/.eslintrc.ava.js
+++ b/.eslintrc.ava.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/.eslintrc.carbon-platform.js
+++ b/.eslintrc.carbon-platform.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/.eslintrc.graphql.js
+++ b/.eslintrc.graphql.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/.eslintrc.jsdoc.js
+++ b/.eslintrc.jsdoc.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/.eslintrc.next.js
+++ b/.eslintrc.next.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/.eslintrc.plugin.js
+++ b/.eslintrc.plugin.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/.eslintrc.react.js
+++ b/.eslintrc.react.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/.eslintrc.storybook.js
+++ b/.eslintrc.storybook.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/.graphqlrc.js
+++ b/.graphqlrc.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/.versionrc.js
+++ b/.versionrc.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright IBM Corp. 2021, 2022
+# Copyright IBM Corp. 2021, 2023
 #
 # This source code is licensed under the Apache-2.0 license found in the
 # LICENSE file in the root directory of this source tree.

--- a/ava.config.mjs
+++ b/ava.config.mjs
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/esbuild.base.mjs
+++ b/esbuild.base.mjs
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/api/src/main/auth/auth-strategy.ts
+++ b/packages/api/src/main/auth/auth-strategy.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/api/src/main/auth/auth.ts
+++ b/packages/api/src/main/auth/auth.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/api/src/main/auth/constants.ts
+++ b/packages/api/src/main/auth/constants.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/api/src/main/auth/index.ts
+++ b/packages/api/src/main/auth/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/api/src/main/auth/interfaces.ts
+++ b/packages/api/src/main/auth/interfaces.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/api/src/main/auth/store.ts
+++ b/packages/api/src/main/auth/store.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/api/src/main/auth/strategies/local-auth-strategy.ts
+++ b/packages/api/src/main/auth/strategies/local-auth-strategy.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/api/src/main/auth/strategies/open-id-strategy.ts
+++ b/packages/api/src/main/auth/strategies/open-id-strategy.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/api/src/main/data-graph/data-graph.ts
+++ b/packages/api/src/main/data-graph/data-graph.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/api/src/main/data-graph/dev-dataset.ts
+++ b/packages/api/src/main/data-graph/dev-dataset.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/api/src/main/data-graph/exceptions/duplicate-query-exception.ts
+++ b/packages/api/src/main/data-graph/exceptions/duplicate-query-exception.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/api/src/main/data-graph/exceptions/unknown-dev-dataset-query-exception.ts
+++ b/packages/api/src/main/data-graph/exceptions/unknown-dev-dataset-query-exception.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/api/src/main/data-graph/gql.ts
+++ b/packages/api/src/main/data-graph/gql.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/api/src/main/data-graph/index.ts
+++ b/packages/api/src/main/data-graph/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/api/src/main/data-graph/inputs/create-user-input.ts
+++ b/packages/api/src/main/data-graph/inputs/create-user-input.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/api/src/main/data-graph/interfaces.ts
+++ b/packages/api/src/main/data-graph/interfaces.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/api/src/main/data-graph/models/library.model.ts
+++ b/packages/api/src/main/data-graph/models/library.model.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/api/src/main/data-graph/models/user.model.ts
+++ b/packages/api/src/main/data-graph/models/user.model.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/api/src/main/logging/constants.ts
+++ b/packages/api/src/main/logging/constants.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/api/src/main/logging/decorators/trace.ts
+++ b/packages/api/src/main/logging/decorators/trace.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/api/src/main/logging/index.ts
+++ b/packages/api/src/main/logging/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/api/src/main/logging/interfaces.ts
+++ b/packages/api/src/main/logging/interfaces.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/api/src/main/logging/logging.ts
+++ b/packages/api/src/main/logging/logging.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/api/src/main/logging/request-log-middleware.ts
+++ b/packages/api/src/main/logging/request-log-middleware.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/api/src/main/logging/safe-stringify.ts
+++ b/packages/api/src/main/logging/safe-stringify.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/api/src/main/messaging/constants.ts
+++ b/packages/api/src/main/messaging/constants.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/api/src/main/messaging/index.ts
+++ b/packages/api/src/main/messaging/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/api/src/main/messaging/interfaces.ts
+++ b/packages/api/src/main/messaging/interfaces.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/api/src/main/messaging/messaging-client.ts
+++ b/packages/api/src/main/messaging/messaging-client.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/api/src/main/messaging/messaging-connection.ts
+++ b/packages/api/src/main/messaging/messaging-connection.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/api/src/main/microservice/constants.ts
+++ b/packages/api/src/main/microservice/constants.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/api/src/main/microservice/exceptions/invalid-input-exception.ts
+++ b/packages/api/src/main/microservice/exceptions/invalid-input-exception.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/api/src/main/microservice/exceptions/query-message-exception.ts
+++ b/packages/api/src/main/microservice/exceptions/query-message-exception.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/api/src/main/microservice/index.ts
+++ b/packages/api/src/main/microservice/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/api/src/main/microservice/interceptors/query-message-exception-interceptor.ts
+++ b/packages/api/src/main/microservice/interceptors/query-message-exception-interceptor.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/api/src/main/microservice/interceptors/rpc-request-log-interceptor.ts
+++ b/packages/api/src/main/microservice/interceptors/rpc-request-log-interceptor.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/api/src/main/microservice/interceptors/uncaught-exception-interceptor.ts
+++ b/packages/api/src/main/microservice/interceptors/uncaught-exception-interceptor.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/api/src/main/microservice/platform-microservice.ts
+++ b/packages/api/src/main/microservice/platform-microservice.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/api/src/main/microservice/status-endpoint/status-controller.ts
+++ b/packages/api/src/main/microservice/status-endpoint/status-controller.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/api/src/main/microservice/status-endpoint/status-module.ts
+++ b/packages/api/src/main/microservice/status-endpoint/status-module.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/api/src/main/runtime/get-env-var.ts
+++ b/packages/api/src/main/runtime/get-env-var.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/api/src/main/runtime/get-environment.ts
+++ b/packages/api/src/main/runtime/get-environment.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/api/src/main/runtime/get-run-mode.ts
+++ b/packages/api/src/main/runtime/get-run-mode.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/api/src/main/runtime/index.ts
+++ b/packages/api/src/main/runtime/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/api/src/main/runtime/interfaces.ts
+++ b/packages/api/src/main/runtime/interfaces.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/api/src/main/runtime/is-debug-enabled.ts
+++ b/packages/api/src/main/runtime/is-debug-enabled.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/api/src/main/runtime/runtime.ts
+++ b/packages/api/src/main/runtime/runtime.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/api/src/test/auth/auth.test.ts
+++ b/packages/api/src/test/auth/auth.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/api/src/test/auth/store.test.ts
+++ b/packages/api/src/test/auth/store.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/api/src/test/auth/strategies/local-auth-strategy.ts
+++ b/packages/api/src/test/auth/strategies/local-auth-strategy.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/api/src/test/auth/strategies/open-id-strategy.ts
+++ b/packages/api/src/test/auth/strategies/open-id-strategy.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/api/src/test/data-graph/data-graph.test.ts
+++ b/packages/api/src/test/data-graph/data-graph.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/api/src/test/data-graph/dev-dataset.test.ts
+++ b/packages/api/src/test/data-graph/dev-dataset.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/api/src/test/data-graph/gql.test.ts
+++ b/packages/api/src/test/data-graph/gql.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/api/src/test/logging/decorators/trace.test.ts
+++ b/packages/api/src/test/logging/decorators/trace.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/api/src/test/logging/logging.test.ts
+++ b/packages/api/src/test/logging/logging.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/api/src/test/logging/request-log-middleware.test.ts
+++ b/packages/api/src/test/logging/request-log-middleware.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/api/src/test/microservice/interceptors/query-message-exception-interceptor.test.ts
+++ b/packages/api/src/test/microservice/interceptors/query-message-exception-interceptor.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/api/src/test/microservice/interceptors/rpc-request-log-interceptor.test.ts
+++ b/packages/api/src/test/microservice/interceptors/rpc-request-log-interceptor.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/api/src/test/microservice/interceptors/uncaught-exception-interceptor.test.ts
+++ b/packages/api/src/test/microservice/interceptors/uncaught-exception-interceptor.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/api/src/test/microservice/status-endpoint/status-controller.e2e-test.ts
+++ b/packages/api/src/test/microservice/status-endpoint/status-controller.e2e-test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/api/src/test/runtime/get-env-var.test.ts
+++ b/packages/api/src/test/runtime/get-env-var.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/api/src/test/runtime/runtime.ts/get-enivronment.test.ts
+++ b/packages/api/src/test/runtime/runtime.ts/get-enivronment.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/api/src/test/runtime/runtime.ts/get-run-mode.test.ts
+++ b/packages/api/src/test/runtime/runtime.ts/get-run-mode.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/api/src/test/runtime/runtime.ts/is-debug-enabled.test.ts
+++ b/packages/api/src/test/runtime/runtime.ts/is-debug-enabled.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/api/src/test/runtime/runtime.ts/with-environment.test.ts
+++ b/packages/api/src/test/runtime/runtime.ts/with-environment.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/eslint-plugin-carbon-platform/lib/index.js
+++ b/packages/eslint-plugin-carbon-platform/lib/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/eslint-plugin-carbon-platform/lib/rules/no-internal-imports.js
+++ b/packages/eslint-plugin-carbon-platform/lib/rules/no-internal-imports.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/eslint-plugin-carbon-platform/lib/rules/no-test-exports.js
+++ b/packages/eslint-plugin-carbon-platform/lib/rules/no-test-exports.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/eslint-plugin-carbon-platform/lib/rules/self-isolated-packages.js
+++ b/packages/eslint-plugin-carbon-platform/lib/rules/self-isolated-packages.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/icons/.svgrrc.cjs
+++ b/packages/icons/.svgrrc.cjs
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/.storybook/layout.js
+++ b/packages/mdx-components/.storybook/layout.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/.storybook/main.js
+++ b/packages/mdx-components/.storybook/main.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/.storybook/preview.js
+++ b/packages/mdx-components/.storybook/preview.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/.storybook/welcome.stories.jsx
+++ b/packages/mdx-components/.storybook/welcome.stories.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/_utils.scss
+++ b/packages/mdx-components/src/main/_utils.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/accordion/_accordion.scss
+++ b/packages/mdx-components/src/main/accordion/_accordion.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/accordion/accordion.stories.jsx
+++ b/packages/mdx-components/src/main/accordion/accordion.stories.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/accordion/accordion.tsx
+++ b/packages/mdx-components/src/main/accordion/accordion.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/anchor-links/_anchor-links.scss
+++ b/packages/mdx-components/src/main/anchor-links/_anchor-links.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/anchor-links/anchor-link.tsx
+++ b/packages/mdx-components/src/main/anchor-links/anchor-link.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/anchor-links/anchor-links.stories.jsx
+++ b/packages/mdx-components/src/main/anchor-links/anchor-links.stories.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/anchor-links/anchor-links.tsx
+++ b/packages/mdx-components/src/main/anchor-links/anchor-links.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/art-direction/art-direction.stories.jsx
+++ b/packages/mdx-components/src/main/art-direction/art-direction.stories.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/art-direction/art-direction.tsx
+++ b/packages/mdx-components/src/main/art-direction/art-direction.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/article-card/_article-card.scss
+++ b/packages/mdx-components/src/main/article-card/_article-card.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/article-card/article-card.stories.jsx
+++ b/packages/mdx-components/src/main/article-card/article-card.stories.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/article-card/article-card.tsx
+++ b/packages/mdx-components/src/main/article-card/article-card.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/aside/_aside.scss
+++ b/packages/mdx-components/src/main/aside/_aside.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/aside/aside.stories.jsx
+++ b/packages/mdx-components/src/main/aside/aside.stories.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/aside/aside.tsx
+++ b/packages/mdx-components/src/main/aside/aside.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/caption/_caption.scss
+++ b/packages/mdx-components/src/main/caption/_caption.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/caption/caption.stories.jsx
+++ b/packages/mdx-components/src/main/caption/caption.stories.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/caption/caption.tsx
+++ b/packages/mdx-components/src/main/caption/caption.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/card-group/_card-group.scss
+++ b/packages/mdx-components/src/main/card-group/_card-group.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/card-group/card-group.stories.jsx
+++ b/packages/mdx-components/src/main/card-group/card-group.stories.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/card-group/card-group.tsx
+++ b/packages/mdx-components/src/main/card-group/card-group.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/code/_code.scss
+++ b/packages/mdx-components/src/main/code/_code.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/code/code.stories.jsx
+++ b/packages/mdx-components/src/main/code/code.stories.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/code/code.tsx
+++ b/packages/mdx-components/src/main/code/code.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/code/path.tsx
+++ b/packages/mdx-components/src/main/code/path.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/divider/_divider.scss
+++ b/packages/mdx-components/src/main/divider/_divider.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/divider/divider.stories.jsx
+++ b/packages/mdx-components/src/main/divider/divider.stories.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/divider/divider.tsx
+++ b/packages/mdx-components/src/main/divider/divider.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/do-dont/_do-dont.scss
+++ b/packages/mdx-components/src/main/do-dont/_do-dont.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/do-dont/do-dont-row.tsx
+++ b/packages/mdx-components/src/main/do-dont/do-dont-row.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/do-dont/do-dont.stories.jsx
+++ b/packages/mdx-components/src/main/do-dont/do-dont.stories.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/do-dont/do-dont.tsx
+++ b/packages/mdx-components/src/main/do-dont/do-dont.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/gif-player/gif-player.stories.jsx
+++ b/packages/mdx-components/src/main/gif-player/gif-player.stories.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/gif-player/gif-player.tsx
+++ b/packages/mdx-components/src/main/gif-player/gif-player.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/grid-transform/_grid.scss
+++ b/packages/mdx-components/src/main/grid-transform/_grid.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/grid-transform/column.tsx
+++ b/packages/mdx-components/src/main/grid-transform/column.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/grid-transform/grid.stories.jsx
+++ b/packages/mdx-components/src/main/grid-transform/grid.stories.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/grid-transform/grid.tsx
+++ b/packages/mdx-components/src/main/grid-transform/grid.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/grid-transform/row.tsx
+++ b/packages/mdx-components/src/main/grid-transform/row.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/image-wrapper/_image-wrapper.scss
+++ b/packages/mdx-components/src/main/image-wrapper/_image-wrapper.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/image-wrapper/image-wrapper.stories.jsx
+++ b/packages/mdx-components/src/main/image-wrapper/image-wrapper.stories.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/image-wrapper/image-wrapper.tsx
+++ b/packages/mdx-components/src/main/image-wrapper/image-wrapper.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/index.scss
+++ b/packages/mdx-components/src/main/index.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/index.ts
+++ b/packages/mdx-components/src/main/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/inline-notification/_inline-notification.scss
+++ b/packages/mdx-components/src/main/inline-notification/_inline-notification.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/inline-notification/inline-notification.stories.jsx
+++ b/packages/mdx-components/src/main/inline-notification/inline-notification.stories.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/inline-notification/inline-notification.tsx
+++ b/packages/mdx-components/src/main/inline-notification/inline-notification.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/interfaces.ts
+++ b/packages/mdx-components/src/main/interfaces.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/link/_link.scss
+++ b/packages/mdx-components/src/main/link/_link.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/link/link.stories.jsx
+++ b/packages/mdx-components/src/main/link/link.stories.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/link/link.tsx
+++ b/packages/mdx-components/src/main/link/link.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/markdown/_markdown.scss
+++ b/packages/mdx-components/src/main/markdown/_markdown.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/markdown/autolink-header/_autolink-header.scss
+++ b/packages/mdx-components/src/main/markdown/autolink-header/_autolink-header.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/markdown/autolink-header/autolink-header.tsx
+++ b/packages/mdx-components/src/main/markdown/autolink-header/autolink-header.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/markdown/blockquote.stories.jsx
+++ b/packages/mdx-components/src/main/markdown/blockquote.stories.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/markdown/blockquote.tsx
+++ b/packages/mdx-components/src/main/markdown/blockquote.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/markdown/h1.tsx
+++ b/packages/mdx-components/src/main/markdown/h1.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/markdown/h2.tsx
+++ b/packages/mdx-components/src/main/markdown/h2.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/markdown/h3.tsx
+++ b/packages/mdx-components/src/main/markdown/h3.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/markdown/h4.tsx
+++ b/packages/mdx-components/src/main/markdown/h4.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/markdown/h5.tsx
+++ b/packages/mdx-components/src/main/markdown/h5.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/markdown/h6.tsx
+++ b/packages/mdx-components/src/main/markdown/h6.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/markdown/headings.stories.jsx
+++ b/packages/mdx-components/src/main/markdown/headings.stories.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/markdown/li.tsx
+++ b/packages/mdx-components/src/main/markdown/li.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/markdown/ol.stories.jsx
+++ b/packages/mdx-components/src/main/markdown/ol.stories.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/markdown/ol.tsx
+++ b/packages/mdx-components/src/main/markdown/ol.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/markdown/p.stories.jsx
+++ b/packages/mdx-components/src/main/markdown/p.stories.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/markdown/p.tsx
+++ b/packages/mdx-components/src/main/markdown/p.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/markdown/ul.stories.jsx
+++ b/packages/mdx-components/src/main/markdown/ul.stories.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/markdown/ul.tsx
+++ b/packages/mdx-components/src/main/markdown/ul.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/mini-card/mini-card.stories.jsx
+++ b/packages/mdx-components/src/main/mini-card/mini-card.stories.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/mini-card/mini-card.tsx
+++ b/packages/mdx-components/src/main/mini-card/mini-card.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/modules.d.ts
+++ b/packages/mdx-components/src/main/modules.d.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/page-description/_page-description.scss
+++ b/packages/mdx-components/src/main/page-description/_page-description.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/page-description/page-description.stories.jsx
+++ b/packages/mdx-components/src/main/page-description/page-description.stories.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/page-description/page-description.tsx
+++ b/packages/mdx-components/src/main/page-description/page-description.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/page-table/_page-table.scss
+++ b/packages/mdx-components/src/main/page-table/_page-table.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/page-table/page-table.stories.jsx
+++ b/packages/mdx-components/src/main/page-table/page-table.stories.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/page-table/page-table.tsx
+++ b/packages/mdx-components/src/main/page-table/page-table.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/preview/_preview.scss
+++ b/packages/mdx-components/src/main/preview/_preview.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/preview/preview.stories.jsx
+++ b/packages/mdx-components/src/main/preview/preview.stories.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/preview/preview.tsx
+++ b/packages/mdx-components/src/main/preview/preview.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/resource-card/_resource-card.scss
+++ b/packages/mdx-components/src/main/resource-card/_resource-card.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/resource-card/resource-card.stories.jsx
+++ b/packages/mdx-components/src/main/resource-card/resource-card.stories.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/resource-card/resource-card.tsx
+++ b/packages/mdx-components/src/main/resource-card/resource-card.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/storybook-demo/_storybook-demo.scss
+++ b/packages/mdx-components/src/main/storybook-demo/_storybook-demo.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/storybook-demo/storybook-demo.stories.jsx
+++ b/packages/mdx-components/src/main/storybook-demo/storybook-demo.stories.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/storybook-demo/storybook-demo.tsx
+++ b/packages/mdx-components/src/main/storybook-demo/storybook-demo.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/tabs/_tabs.scss
+++ b/packages/mdx-components/src/main/tabs/_tabs.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/tabs/select.tsx
+++ b/packages/mdx-components/src/main/tabs/select.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/tabs/tab-list.tsx
+++ b/packages/mdx-components/src/main/tabs/tab-list.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/tabs/tab.tsx
+++ b/packages/mdx-components/src/main/tabs/tab.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/tabs/tabs.stories.jsx
+++ b/packages/mdx-components/src/main/tabs/tabs.stories.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/tabs/tabs.tsx
+++ b/packages/mdx-components/src/main/tabs/tabs.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/title/title.stories.jsx
+++ b/packages/mdx-components/src/main/title/title.stories.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/title/title.tsx
+++ b/packages/mdx-components/src/main/title/title.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/utils.ts
+++ b/packages/mdx-components/src/main/utils.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/video/_video.scss
+++ b/packages/mdx-components/src/main/video/_video.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/video/video.stories.jsx
+++ b/packages/mdx-components/src/main/video/video.stories.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/main/video/video.tsx
+++ b/packages/mdx-components/src/main/video/video.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/test/all-components.test.tsx
+++ b/packages/mdx-components/src/test/all-components.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/test/art-direction.test.tsx
+++ b/packages/mdx-components/src/test/art-direction.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/test/article-card.test.tsx
+++ b/packages/mdx-components/src/test/article-card.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/test/column.test.tsx
+++ b/packages/mdx-components/src/test/column.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/test/h2.test.tsx
+++ b/packages/mdx-components/src/test/h2.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/test/mini-card.test.tsx
+++ b/packages/mdx-components/src/test/mini-card.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/test/page-table.test.tsx
+++ b/packages/mdx-components/src/test/page-table.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/test/resource-card.test.tsx
+++ b/packages/mdx-components/src/test/resource-card.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/test/row.test.tsx
+++ b/packages/mdx-components/src/test/row.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/test/tab.test.tsx
+++ b/packages/mdx-components/src/test/tab.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-components/src/test/video.test.tsx
+++ b/packages/mdx-components/src/test/video.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-processor/src/main/exceptions/mdx-compile-exception.ts
+++ b/packages/mdx-processor/src/main/exceptions/mdx-compile-exception.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-processor/src/main/index.ts
+++ b/packages/mdx-processor/src/main/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-processor/src/main/mdx-processor.ts
+++ b/packages/mdx-processor/src/main/mdx-processor.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-processor/src/test/mdx-processor.test.ts
+++ b/packages/mdx-processor/src/test/mdx-processor.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-processor/src/types/react-jsx-runtime.d.ts
+++ b/packages/mdx-processor/src/types/react-jsx-runtime.d.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-processor/src/types/rehype-urls.d.ts
+++ b/packages/mdx-processor/src/types/rehype-urls.d.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-sanitizer/src/main/exceptions/component-replaced-exception.ts
+++ b/packages/mdx-sanitizer/src/main/exceptions/component-replaced-exception.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-sanitizer/src/main/exceptions/export-found-exception.ts
+++ b/packages/mdx-sanitizer/src/main/exceptions/export-found-exception.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-sanitizer/src/main/exceptions/import-found-exception.ts
+++ b/packages/mdx-sanitizer/src/main/exceptions/import-found-exception.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-sanitizer/src/main/exceptions/unknown-component-exception.ts
+++ b/packages/mdx-sanitizer/src/main/exceptions/unknown-component-exception.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-sanitizer/src/main/index.ts
+++ b/packages/mdx-sanitizer/src/main/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-sanitizer/src/main/interfaces.ts
+++ b/packages/mdx-sanitizer/src/main/interfaces.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-sanitizer/src/main/mdx-sanitizer-plugin.ts
+++ b/packages/mdx-sanitizer/src/main/mdx-sanitizer-plugin.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-sanitizer/src/test/mdx-sanitizer-plugin.test.ts
+++ b/packages/mdx-sanitizer/src/test/mdx-sanitizer-plugin.test.ts
@@ -1,11 +1,11 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/mdx-sanitizer/src/types/html-comment-regex.d.ts
+++ b/packages/mdx-sanitizer/src/types/html-comment-regex.d.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/micromanage-cli/lib/build.js
+++ b/packages/micromanage-cli/lib/build.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/micromanage-cli/lib/changed.js
+++ b/packages/micromanage-cli/lib/changed.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/micromanage-cli/lib/docker/build.js
+++ b/packages/micromanage-cli/lib/docker/build.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/micromanage-cli/lib/docker/index.js
+++ b/packages/micromanage-cli/lib/docker/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/micromanage-cli/lib/index.js
+++ b/packages/micromanage-cli/lib/index.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/micromanage-cli/lib/install.js
+++ b/packages/micromanage-cli/lib/install.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/micromanage-cli/lib/package/dependents.js
+++ b/packages/micromanage-cli/lib/package/dependents.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/micromanage-cli/lib/package/index.js
+++ b/packages/micromanage-cli/lib/package/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/micromanage-cli/lib/package/publish.js
+++ b/packages/micromanage-cli/lib/package/publish.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/micromanage-cli/lib/service/dependencies.js
+++ b/packages/micromanage-cli/lib/service/dependencies.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/micromanage-cli/lib/service/index.js
+++ b/packages/micromanage-cli/lib/service/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/micromanage-cli/lib/uninstall.js
+++ b/packages/micromanage-cli/lib/uninstall.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/micromanage-cli/lib/utils.js
+++ b/packages/micromanage-cli/lib/utils.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/micromanage-cli/lib/version.js
+++ b/packages/micromanage-cli/lib/version.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/micromanage-cli/scripts/build_readme
+++ b/packages/micromanage-cli/scripts/build_readme
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright IBM Corp. 2022, 2022
+# Copyright IBM Corp. 2022, 2023
 #
 # This source code is licensed under the Apache-2.0 license found in the
 # LICENSE file in the root directory of this source tree.

--- a/scripts/add-pr-comment.mjs
+++ b/scripts/add-pr-comment.mjs
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/scripts/check_package_locks
+++ b/scripts/check_package_locks
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright IBM Corp. 2021, 2022
+# Copyright IBM Corp. 2021, 2023
 #
 # This source code is licensed under the Apache-2.0 license found in the
 # LICENSE file in the root directory of this source tree.

--- a/scripts/clean
+++ b/scripts/clean
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright IBM Corp. 2021, 2022
+# Copyright IBM Corp. 2021, 2023
 #
 # This source code is licensed under the Apache-2.0 license found in the
 # LICENSE file in the root directory of this source tree.

--- a/scripts/format-package-json.mjs
+++ b/scripts/format-package-json.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/scripts/lint
+++ b/scripts/lint
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright IBM Corp. 2021, 2022
+# Copyright IBM Corp. 2021, 2023
 #
 # This source code is licensed under the Apache-2.0 license found in the
 # LICENSE file in the root directory of this source tree.

--- a/scripts/lint_and_fix
+++ b/scripts/lint_and_fix
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright IBM Corp. 2021, 2022
+# Copyright IBM Corp. 2021, 2023
 #
 # This source code is licensed under the Apache-2.0 license found in the
 # LICENSE file in the root directory of this source tree.

--- a/scripts/prepare
+++ b/scripts/prepare
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright IBM Corp. 2021, 2022
+# Copyright IBM Corp. 2021, 2023
 #
 # This source code is licensed under the Apache-2.0 license found in the
 # LICENSE file in the root directory of this source tree.

--- a/services/data-graph/Dockerfile
+++ b/services/data-graph/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright IBM Corp. 2022, 2022
+# Copyright IBM Corp. 2022, 2023
 #
 # This source code is licensed under the Apache-2.0 license found in the
 # LICENSE file in the root directory of this source tree.

--- a/services/data-graph/esbuild.js
+++ b/services/data-graph/esbuild.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/data-graph/src/main/constants.ts
+++ b/services/data-graph/src/main/constants.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/data-graph/src/main/data-graph-controller.ts
+++ b/services/data-graph/src/main/data-graph-controller.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/data-graph/src/main/data-graph-module.ts
+++ b/services/data-graph/src/main/data-graph-module.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/data-graph/src/main/generate-schema.ts
+++ b/services/data-graph/src/main/generate-schema.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/data-graph/src/main/index.ts
+++ b/services/data-graph/src/main/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/data-graph/src/main/libraries/libraries-module.ts
+++ b/services/data-graph/src/main/libraries/libraries-module.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/data-graph/src/main/libraries/libraries-resolver.ts
+++ b/services/data-graph/src/main/libraries/libraries-resolver.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/data-graph/src/main/libraries/libraries-service.ts
+++ b/services/data-graph/src/main/libraries/libraries-service.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/data-graph/src/main/request-log-plugin.ts
+++ b/services/data-graph/src/main/request-log-plugin.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/data-graph/src/main/users/users-module.ts
+++ b/services/data-graph/src/main/users/users-module.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/data-graph/src/main/users/users-resolver.ts
+++ b/services/data-graph/src/main/users/users-resolver.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/data-graph/src/main/users/users-service.ts
+++ b/services/data-graph/src/main/users/users-service.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/data-graph/src/main/validate-data-graph-message.ts
+++ b/services/data-graph/src/main/validate-data-graph-message.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/data-graph/src/test/data-graph-controller.test.ts
+++ b/services/data-graph/src/test/data-graph-controller.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/data-graph/src/test/data-graph-module.e2e-test.ts
+++ b/services/data-graph/src/test/data-graph-module.e2e-test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/data-graph/src/test/libraries/libraries-resolver.test.ts
+++ b/services/data-graph/src/test/libraries/libraries-resolver.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/data-graph/src/test/libraries/libraries-service.test.ts
+++ b/services/data-graph/src/test/libraries/libraries-service.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/logging/Dockerfile
+++ b/services/logging/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright IBM Corp. 2022, 2022
+# Copyright IBM Corp. 2022, 2023
 #
 # This source code is licensed under the Apache-2.0 license found in the
 # LICENSE file in the root directory of this source tree.

--- a/services/logging/esbuild.js
+++ b/services/logging/esbuild.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/logging/src/main/constants.ts
+++ b/services/logging/src/main/constants.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/logging/src/main/index.ts
+++ b/services/logging/src/main/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/logging/src/main/log-dna-service.ts
+++ b/services/logging/src/main/log-dna-service.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/logging/src/main/logging-controller.ts
+++ b/services/logging/src/main/logging-controller.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/logging/src/main/logging-module.ts
+++ b/services/logging/src/main/logging-module.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/logging/src/main/validate-log-message.ts
+++ b/services/logging/src/main/validate-log-message.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/logging/src/test/log-dna-service.test.ts
+++ b/services/logging/src/test/log-dna-service.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/logging/src/test/logging-controller.test.ts
+++ b/services/logging/src/test/logging-controller.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/.storybook/NextImage.js
+++ b/services/web-app/.storybook/NextImage.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/.storybook/layout.js
+++ b/services/web-app/.storybook/layout.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/.storybook/main.js
+++ b/services/web-app/.storybook/main.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/.storybook/next-image.module.scss
+++ b/services/web-app/.storybook/next-image.module.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/.storybook/preview.js
+++ b/services/web-app/.storybook/preview.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/Dockerfile
+++ b/services/web-app/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright IBM Corp. 2022, 2022
+# Copyright IBM Corp. 2022, 2023
 #
 # This source code is licensed under the Apache-2.0 license found in the
 # LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/asset-catalog-item/asset-catalog-item-meta/asset-catalog-item-meta.js
+++ b/services/web-app/components/asset-catalog-item/asset-catalog-item-meta/asset-catalog-item-meta.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/asset-catalog-item/asset-catalog-item-meta/asset-catalog-item-meta.module.scss
+++ b/services/web-app/components/asset-catalog-item/asset-catalog-item-meta/asset-catalog-item-meta.module.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/asset-catalog-item/asset-catalog-item-meta/index.js
+++ b/services/web-app/components/asset-catalog-item/asset-catalog-item-meta/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/asset-catalog-item/asset-catalog-item.js
+++ b/services/web-app/components/asset-catalog-item/asset-catalog-item.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/asset-catalog-item/asset-catalog-item.module.scss
+++ b/services/web-app/components/asset-catalog-item/asset-catalog-item.module.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/asset-catalog-item/index.js
+++ b/services/web-app/components/asset-catalog-item/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/asset-details/asset-details.js
+++ b/services/web-app/components/asset-details/asset-details.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/asset-details/asset-details.module.scss
+++ b/services/web-app/components/asset-details/asset-details.module.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/asset-details/index.js
+++ b/services/web-app/components/asset-details/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/assets-catalog/assets-catalog.js
+++ b/services/web-app/components/assets-catalog/assets-catalog.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/assets-catalog/index.js
+++ b/services/web-app/components/assets-catalog/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/auth/require-auth.js
+++ b/services/web-app/components/auth/require-auth.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/back-to-top/back-to-top.js
+++ b/services/web-app/components/back-to-top/back-to-top.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/back-to-top/back-to-top.module.scss
+++ b/services/web-app/components/back-to-top/back-to-top.module.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/back-to-top/index.js
+++ b/services/web-app/components/back-to-top/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/banner/banner.js
+++ b/services/web-app/components/banner/banner.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/banner/banner.module.scss
+++ b/services/web-app/components/banner/banner.module.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/banner/index.js
+++ b/services/web-app/components/banner/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/catalog-filters/catalog-filters.js
+++ b/services/web-app/components/catalog-filters/catalog-filters.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/catalog-filters/catalog-filters.module.scss
+++ b/services/web-app/components/catalog-filters/catalog-filters.module.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/catalog-filters/index.js
+++ b/services/web-app/components/catalog-filters/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/catalog-item-meta/catalog-item-meta.js
+++ b/services/web-app/components/catalog-item-meta/catalog-item-meta.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/catalog-item-meta/catalog-item-meta.module.scss
+++ b/services/web-app/components/catalog-item-meta/catalog-item-meta.module.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/catalog-item-meta/index.js
+++ b/services/web-app/components/catalog-item-meta/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/catalog-list/catalog-list.js
+++ b/services/web-app/components/catalog-list/catalog-list.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/catalog-list/catalog-list.module.scss
+++ b/services/web-app/components/catalog-list/catalog-list.module.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/catalog-list/index.js
+++ b/services/web-app/components/catalog-list/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/catalog-multislect-filter/catalog-multiselect-filter.js
+++ b/services/web-app/components/catalog-multislect-filter/catalog-multiselect-filter.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/catalog-multislect-filter/catalog-multiselect-filter.module.scss
+++ b/services/web-app/components/catalog-multislect-filter/catalog-multiselect-filter.module.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/catalog-multislect-filter/index.js
+++ b/services/web-app/components/catalog-multislect-filter/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/catalog-pagination/catalog-pagination.js
+++ b/services/web-app/components/catalog-pagination/catalog-pagination.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/catalog-pagination/catalog-pagination.module.scss
+++ b/services/web-app/components/catalog-pagination/catalog-pagination.module.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/catalog-pagination/index.js
+++ b/services/web-app/components/catalog-pagination/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/catalog-results/catalog-results.js
+++ b/services/web-app/components/catalog-results/catalog-results.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/catalog-results/catalog-results.module.scss
+++ b/services/web-app/components/catalog-results/catalog-results.module.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/catalog-results/index.js
+++ b/services/web-app/components/catalog-results/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/catalog-search/catalog-search.js
+++ b/services/web-app/components/catalog-search/catalog-search.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/catalog-search/catalog-search.module.scss
+++ b/services/web-app/components/catalog-search/catalog-search.module.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/catalog-search/index.js
+++ b/services/web-app/components/catalog-search/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/catalog-sort/catalog-sort.js
+++ b/services/web-app/components/catalog-sort/catalog-sort.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/catalog-sort/catalog-sort.module.scss
+++ b/services/web-app/components/catalog-sort/catalog-sort.module.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/catalog-sort/index.js
+++ b/services/web-app/components/catalog-sort/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/catalog/catalog.js
+++ b/services/web-app/components/catalog/catalog.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/catalog/catalog.module.scss
+++ b/services/web-app/components/catalog/catalog.module.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/catalog/index.js
+++ b/services/web-app/components/catalog/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/color-block/color-block.js
+++ b/services/web-app/components/color-block/color-block.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/color-block/color-block.module.scss
+++ b/services/web-app/components/color-block/color-block.module.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/color-block/index.js
+++ b/services/web-app/components/color-block/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/color-grid/color-grid.js
+++ b/services/web-app/components/color-grid/color-grid.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/color-grid/color-grid.module.scss
+++ b/services/web-app/components/color-grid/color-grid.module.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/color-grid/index.js
+++ b/services/web-app/components/color-grid/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/color-palette/color-palette-color.js
+++ b/services/web-app/components/color-palette/color-palette-color.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/color-palette/color-palette.js
+++ b/services/web-app/components/color-palette/color-palette.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/color-palette/color-palette.module.scss
+++ b/services/web-app/components/color-palette/color-palette.module.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/color-palette/index.js
+++ b/services/web-app/components/color-palette/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/color-palette/palettes-container.js
+++ b/services/web-app/components/color-palette/palettes-container.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/color-token-table/color-token-table.js
+++ b/services/web-app/components/color-token-table/color-token-table.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/color-token-table/color-token-table.module.scss
+++ b/services/web-app/components/color-token-table/color-token-table.module.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/color-token-table/index.js
+++ b/services/web-app/components/color-token-table/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/content-wrapper/content-wrapper.js
+++ b/services/web-app/components/content-wrapper/content-wrapper.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/content-wrapper/content-wrapper.module.scss
+++ b/services/web-app/components/content-wrapper/content-wrapper.module.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/content-wrapper/index.js
+++ b/services/web-app/components/content-wrapper/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/dashboard/dashboard-item.js
+++ b/services/web-app/components/dashboard/dashboard-item.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/dashboard/dashboard-item.module.scss
+++ b/services/web-app/components/dashboard/dashboard-item.module.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/dashboard/dashboard.js
+++ b/services/web-app/components/dashboard/dashboard.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/dashboard/dashboard.module.scss
+++ b/services/web-app/components/dashboard/dashboard.module.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/dashboard/index.js
+++ b/services/web-app/components/dashboard/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/demo-links/demo-links.js
+++ b/services/web-app/components/demo-links/demo-links.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/demo-links/index.js
+++ b/services/web-app/components/demo-links/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/design-kit-catalog-item/design-kit-catalog-item.js
+++ b/services/web-app/components/design-kit-catalog-item/design-kit-catalog-item.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/design-kit-catalog-item/design-kit-catalog-item.module.scss
+++ b/services/web-app/components/design-kit-catalog-item/design-kit-catalog-item.module.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/design-kit-catalog-item/index.js
+++ b/services/web-app/components/design-kit-catalog-item/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/design-kit-icon/design-kit-icon.js
+++ b/services/web-app/components/design-kit-icon/design-kit-icon.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/design-kit-icon/design-kit-icon.module.scss
+++ b/services/web-app/components/design-kit-icon/design-kit-icon.module.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/design-kit-icon/index.js
+++ b/services/web-app/components/design-kit-icon/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/design-kits-catalog/design-kits-catalog.js
+++ b/services/web-app/components/design-kits-catalog/design-kits-catalog.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/design-kits-catalog/index.js
+++ b/services/web-app/components/design-kits-catalog/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/do-dont/do-dont.module.scss
+++ b/services/web-app/components/do-dont/do-dont.module.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/feature-card/feature-card.js
+++ b/services/web-app/components/feature-card/feature-card.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/feature-card/feature-card.module.scss
+++ b/services/web-app/components/feature-card/feature-card.module.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/feature-card/index.js
+++ b/services/web-app/components/feature-card/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/filterable-design-kit-table/filterable-design-kit-table.js
+++ b/services/web-app/components/filterable-design-kit-table/filterable-design-kit-table.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/filterable-design-kit-table/filterable-design-kit-table.module.scss
+++ b/services/web-app/components/filterable-design-kit-table/filterable-design-kit-table.module.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/filterable-design-kit-table/index.js
+++ b/services/web-app/components/filterable-design-kit-table/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/footer/footer.js
+++ b/services/web-app/components/footer/footer.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/footer/footer.module.scss
+++ b/services/web-app/components/footer/footer.module.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/footer/index.js
+++ b/services/web-app/components/footer/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/framework-icon/framework-icon.js
+++ b/services/web-app/components/framework-icon/framework-icon.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/framework-icon/framework-icon.module.scss
+++ b/services/web-app/components/framework-icon/framework-icon.module.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/framework-icon/index.js
+++ b/services/web-app/components/framework-icon/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/glossary/glossary-list/glossary-list.js
+++ b/services/web-app/components/glossary/glossary-list/glossary-list.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/glossary/glossary-list/index.js
+++ b/services/web-app/components/glossary/glossary-list/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/glossary/glossary-nav/glossary-nav.js
+++ b/services/web-app/components/glossary/glossary-nav/glossary-nav.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/glossary/glossary-nav/index.js
+++ b/services/web-app/components/glossary/glossary-nav/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/glossary/glossary.js
+++ b/services/web-app/components/glossary/glossary.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/glossary/index.js
+++ b/services/web-app/components/glossary/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/hero/hero.js
+++ b/services/web-app/components/hero/hero.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/hero/hero.module.scss
+++ b/services/web-app/components/hero/hero.module.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/hero/index.js
+++ b/services/web-app/components/hero/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/image/image.js
+++ b/services/web-app/components/image/image.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/image/image.module.scss
+++ b/services/web-app/components/image/image.module.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/image/index.js
+++ b/services/web-app/components/image/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/library-catalog-item/index.js
+++ b/services/web-app/components/library-catalog-item/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/library-catalog-item/library-catalog-item.js
+++ b/services/web-app/components/library-catalog-item/library-catalog-item.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/library-catalog-item/library-catalog-item.module.scss
+++ b/services/web-app/components/library-catalog-item/library-catalog-item.module.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/library-catalog/index.js
+++ b/services/web-app/components/library-catalog/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/library-catalog/library-catalog.js
+++ b/services/web-app/components/library-catalog/library-catalog.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/mdx-icon/index.js
+++ b/services/web-app/components/mdx-icon/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/mdx-icon/mdx-icon.js
+++ b/services/web-app/components/mdx-icon/mdx-icon.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/mdx-icon/mdx-icon.module.scss
+++ b/services/web-app/components/mdx-icon/mdx-icon.module.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/mdx-notification/index.js
+++ b/services/web-app/components/mdx-notification/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/mdx-notification/mdx-notification.js
+++ b/services/web-app/components/mdx-notification/mdx-notification.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/mdx-notification/mdx-notification.module.scss
+++ b/services/web-app/components/mdx-notification/mdx-notification.module.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/mdx-page/errors/content-not-found-exception-content.js
+++ b/services/web-app/components/mdx-page/errors/content-not-found-exception-content.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/mdx-page/errors/export-found-exception-content.js
+++ b/services/web-app/components/mdx-page/errors/export-found-exception-content.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/mdx-page/errors/fallback-exception-content.js
+++ b/services/web-app/components/mdx-page/errors/fallback-exception-content.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/mdx-page/errors/full-page-error/full-page-error.js
+++ b/services/web-app/components/mdx-page/errors/full-page-error/full-page-error.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/mdx-page/errors/full-page-error/full-page-error.module.scss
+++ b/services/web-app/components/mdx-page/errors/full-page-error/full-page-error.module.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/mdx-page/errors/full-page-error/index.js
+++ b/services/web-app/components/mdx-page/errors/full-page-error/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/mdx-page/errors/import-found-exception-content.js
+++ b/services/web-app/components/mdx-page/errors/import-found-exception-content.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/mdx-page/errors/mdx-compile-exception-content.js
+++ b/services/web-app/components/mdx-page/errors/mdx-compile-exception-content.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/mdx-page/errors/warnings-rollup/index.js
+++ b/services/web-app/components/mdx-page/errors/warnings-rollup/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/mdx-page/errors/warnings-rollup/warnings-rollup.js
+++ b/services/web-app/components/mdx-page/errors/warnings-rollup/warnings-rollup.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/mdx-page/errors/warnings-rollup/warnings-rollup.module.scss
+++ b/services/web-app/components/mdx-page/errors/warnings-rollup/warnings-rollup.module.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/mdx-page/index.js
+++ b/services/web-app/components/mdx-page/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/mdx-page/mdx-page.js
+++ b/services/web-app/components/mdx-page/mdx-page.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/mdx/components.js
+++ b/services/web-app/components/mdx/components.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/mdx/index.js
+++ b/services/web-app/components/mdx/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/nav-primary/index.js
+++ b/services/web-app/components/nav-primary/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/nav-primary/nav-primary.js
+++ b/services/web-app/components/nav-primary/nav-primary.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/nav-primary/nav-primary.module.scss
+++ b/services/web-app/components/nav-primary/nav-primary.module.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/nav-secondary/index.js
+++ b/services/web-app/components/nav-secondary/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/nav-secondary/nav-secondary.js
+++ b/services/web-app/components/nav-secondary/nav-secondary.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/nav-secondary/nav-secondary.module.scss
+++ b/services/web-app/components/nav-secondary/nav-secondary.module.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/nav-tree/index.js
+++ b/services/web-app/components/nav-tree/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/nav-tree/nav-tree.js
+++ b/services/web-app/components/nav-tree/nav-tree.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/nav-tree/nav-tree.module.scss
+++ b/services/web-app/components/nav-tree/nav-tree.module.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/next-link.js
+++ b/services/web-app/components/next-link.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/page-breadcrumb/index.js
+++ b/services/web-app/components/page-breadcrumb/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/page-breadcrumb/page-breadcrumb.js
+++ b/services/web-app/components/page-breadcrumb/page-breadcrumb.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/page-breadcrumb/page-breadcrumb.module.scss
+++ b/services/web-app/components/page-breadcrumb/page-breadcrumb.module.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/page-header/index.js
+++ b/services/web-app/components/page-header/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/page-header/page-header.js
+++ b/services/web-app/components/page-header/page-header.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/page-header/page-header.module.scss
+++ b/services/web-app/components/page-header/page-header.module.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/page-loading/index.js
+++ b/services/web-app/components/page-loading/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/page-loading/page-loading.js
+++ b/services/web-app/components/page-loading/page-loading.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/page-loading/page-loading.module.scss
+++ b/services/web-app/components/page-loading/page-loading.module.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/page-nav/index.js
+++ b/services/web-app/components/page-nav/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/page-nav/page-nav.js
+++ b/services/web-app/components/page-nav/page-nav.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/page-nav/page-nav.module.scss
+++ b/services/web-app/components/page-nav/page-nav.module.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/page-not-found/index.js
+++ b/services/web-app/components/page-not-found/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/page-not-found/page-not-found.js
+++ b/services/web-app/components/page-not-found/page-not-found.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/page-not-found/page-not-found.module.scss
+++ b/services/web-app/components/page-not-found/page-not-found.module.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/page-table/page-table.module.scss
+++ b/services/web-app/components/page-table/page-table.module.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/page-tabs/index.js
+++ b/services/web-app/components/page-tabs/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/page-tabs/page-tabs.js
+++ b/services/web-app/components/page-tabs/page-tabs.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/page-tabs/page-tabs.module.scss
+++ b/services/web-app/components/page-tabs/page-tabs.module.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/profile/index.js
+++ b/services/web-app/components/profile/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/profile/profile.js
+++ b/services/web-app/components/profile/profile.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/profile/profile.module.scss
+++ b/services/web-app/components/profile/profile.module.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/sort-by-dropdown/index.js
+++ b/services/web-app/components/sort-by-dropdown/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/sort-by-dropdown/sort-by-dropdown.js
+++ b/services/web-app/components/sort-by-dropdown/sort-by-dropdown.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/sort-by-dropdown/sort-by-dropdown.module.scss
+++ b/services/web-app/components/sort-by-dropdown/sort-by-dropdown.module.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/status-icon/index.js
+++ b/services/web-app/components/status-icon/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/status-icon/status-icon.js
+++ b/services/web-app/components/status-icon/status-icon.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/status-icon/status-icon.module.scss
+++ b/services/web-app/components/status-icon/status-icon.module.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/status-indicator-table/index.js
+++ b/services/web-app/components/status-indicator-table/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/status-indicator-table/status-indicator-row.js
+++ b/services/web-app/components/status-indicator-table/status-indicator-row.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/status-indicator-table/status-indicator-table.js
+++ b/services/web-app/components/status-indicator-table/status-indicator-table.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/status-indicator-table/status-indicator.module.scss
+++ b/services/web-app/components/status-indicator-table/status-indicator.module.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/svg-libraries/action-bar/action-bar.js
+++ b/services/web-app/components/svg-libraries/action-bar/action-bar.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/svg-libraries/action-bar/index.js
+++ b/services/web-app/components/svg-libraries/action-bar/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/svg-libraries/filter-row/filter-row.js
+++ b/services/web-app/components/svg-libraries/filter-row/filter-row.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/svg-libraries/filter-row/index.js
+++ b/services/web-app/components/svg-libraries/filter-row/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/svg-libraries/icon-library/icon-category.js
+++ b/services/web-app/components/svg-libraries/icon-library/icon-category.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/svg-libraries/icon-library/icon-library.js
+++ b/services/web-app/components/svg-libraries/icon-library/icon-library.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/svg-libraries/icon-library/index.js
+++ b/services/web-app/components/svg-libraries/icon-library/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/svg-libraries/no-result/index.js
+++ b/services/web-app/components/svg-libraries/no-result/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/svg-libraries/no-result/no-result.js
+++ b/services/web-app/components/svg-libraries/no-result/no-result.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/svg-libraries/pictogram-library/index.js
+++ b/services/web-app/components/svg-libraries/pictogram-library/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/svg-libraries/pictogram-library/pictogram-category.js
+++ b/services/web-app/components/svg-libraries/pictogram-library/pictogram-category.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/svg-libraries/pictogram-library/pictogram-library.js
+++ b/services/web-app/components/svg-libraries/pictogram-library/pictogram-library.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/svg-libraries/svg-card/index.js
+++ b/services/web-app/components/svg-libraries/svg-card/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/svg-libraries/svg-card/svg-card.js
+++ b/services/web-app/components/svg-libraries/svg-card/svg-card.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/type-tag/index.js
+++ b/services/web-app/components/type-tag/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/type-tag/type-tag.js
+++ b/services/web-app/components/type-tag/type-tag.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/type-tag/type-tag.module.scss
+++ b/services/web-app/components/type-tag/type-tag.module.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/type/index.js
+++ b/services/web-app/components/type/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/type/type-scale-table.js
+++ b/services/web-app/components/type/type-scale-table.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/type/type-scale.module.scss
+++ b/services/web-app/components/type/type-scale.module.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/type/type-weight.js
+++ b/services/web-app/components/type/type-weight.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/type/type-weight.module.scss
+++ b/services/web-app/components/type/type-weight.module.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/typeset-style/index.js
+++ b/services/web-app/components/typeset-style/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/typeset-style/input-range.js
+++ b/services/web-app/components/typeset-style/input-range.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/typeset-style/sticky-container.js
+++ b/services/web-app/components/typeset-style/sticky-container.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/typeset-style/typeset-example.js
+++ b/services/web-app/components/typeset-style/typeset-example.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/typeset-style/typeset-example.module.scss
+++ b/services/web-app/components/typeset-style/typeset-example.module.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/typeset-style/typeset-style.js
+++ b/services/web-app/components/typeset-style/typeset-style.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/typeset-style/typeset-style.module.scss
+++ b/services/web-app/components/typeset-style/typeset-style.module.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/with-loading/index.js
+++ b/services/web-app/components/with-loading/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/components/with-loading/with-loading.js
+++ b/services/web-app/components/with-loading/with-loading.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/config/constants.js
+++ b/services/web-app/config/constants.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/config/redirects.mjs
+++ b/services/web-app/config/redirects.mjs
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/contexts/auth.js
+++ b/services/web-app/contexts/auth.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/data/asset-types.js
+++ b/services/web-app/data/asset-types.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/data/color-tokens.js
+++ b/services/web-app/data/color-tokens.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/data/colors.js
+++ b/services/web-app/data/colors.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/data/data-visualization/palettes.js
+++ b/services/web-app/data/data-visualization/palettes.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/data/design-kit-types.js
+++ b/services/web-app/data/design-kit-types.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/data/design-kits.js
+++ b/services/web-app/data/design-kits.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/data/design-tools.js
+++ b/services/web-app/data/design-tools.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/data/filters.js
+++ b/services/web-app/data/filters.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/data/framework.js
+++ b/services/web-app/data/framework.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/data/glossary.js
+++ b/services/web-app/data/glossary.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/data/html-tags.js
+++ b/services/web-app/data/html-tags.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/data/libraries.mjs
+++ b/services/web-app/data/libraries.mjs
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/data/licenses.js
+++ b/services/web-app/data/licenses.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/data/nav-data.js
+++ b/services/web-app/data/nav-data.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/data/page-headers.js
+++ b/services/web-app/data/page-headers.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/data/platform.js
+++ b/services/web-app/data/platform.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/data/remote-pages.js
+++ b/services/web-app/data/remote-pages.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/data/sort.js
+++ b/services/web-app/data/sort.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/data/status-indicators/palettes.js
+++ b/services/web-app/data/status-indicators/palettes.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/data/status.js
+++ b/services/web-app/data/status.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/data/tags.js
+++ b/services/web-app/data/tags.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/data/teams.js
+++ b/services/web-app/data/teams.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/data/type-scale.js
+++ b/services/web-app/data/type-scale.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/data/type-sets.js
+++ b/services/web-app/data/type-sets.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/data/view.js
+++ b/services/web-app/data/view.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/esbuild.mjs
+++ b/services/web-app/esbuild.mjs
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/exceptions/content-not-found-exception.js
+++ b/services/web-app/exceptions/content-not-found-exception.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/layouts/layout/index.js
+++ b/services/web-app/layouts/layout/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/layouts/layout/layout.js
+++ b/services/web-app/layouts/layout/layout.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/layouts/layout/layout.module.scss
+++ b/services/web-app/layouts/layout/layout.module.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/lib/file-cache.js
+++ b/services/web-app/lib/file-cache.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/lib/github.js
+++ b/services/web-app/lib/github.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/middleware/require-session.js
+++ b/services/web-app/middleware/require-session.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/next.config.mjs
+++ b/services/web-app/next.config.mjs
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/pages/404.js
+++ b/services/web-app/pages/404.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/pages/[...remote-mdx-path].js
+++ b/services/web-app/pages/[...remote-mdx-path].js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/pages/_app.js
+++ b/services/web-app/pages/_app.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/pages/about-carbon/how-carbon-works.module.scss
+++ b/services/web-app/pages/about-carbon/how-carbon-works.module.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/pages/about-carbon/meetups.module.scss
+++ b/services/web-app/pages/about-carbon/meetups.module.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/pages/about-carbon/platform-roadmap.js
+++ b/services/web-app/pages/about-carbon/platform-roadmap.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/pages/about-carbon/platform-roadmap.module.scss
+++ b/services/web-app/pages/about-carbon/platform-roadmap.module.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/pages/api/auth-callback.js
+++ b/services/web-app/pages/api/auth-callback.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/pages/api/login.js
+++ b/services/web-app/pages/api/login.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/pages/api/logout.js
+++ b/services/web-app/pages/api/logout.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/pages/api/user.js
+++ b/services/web-app/pages/api/user.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/pages/assets/components.js
+++ b/services/web-app/pages/assets/components.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/pages/assets/functions.js
+++ b/services/web-app/pages/assets/functions.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/pages/assets/patterns.js
+++ b/services/web-app/pages/assets/patterns.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/pages/assets/templates.js
+++ b/services/web-app/pages/assets/templates.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/pages/common-mdx-errors/index.js
+++ b/services/web-app/pages/common-mdx-errors/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/pages/common-mdx-errors/index.module.scss
+++ b/services/web-app/pages/common-mdx-errors/index.module.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/pages/data-visualization/dataviz.module.scss
+++ b/services/web-app/pages/data-visualization/dataviz.module.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/pages/data-visualization/index.js
+++ b/services/web-app/pages/data-visualization/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/pages/design-kits.js
+++ b/services/web-app/pages/design-kits.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/pages/elements/2x-grid/grid-demo.module.scss
+++ b/services/web-app/pages/elements/2x-grid/grid-demo.module.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/pages/elements/color/color-block.module.scss
+++ b/services/web-app/pages/elements/color/color-block.module.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/pages/index.js
+++ b/services/web-app/pages/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/pages/index/index.module.scss
+++ b/services/web-app/pages/index/index.module.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/pages/libraries/[host]/[org]/[repo]/[library]/[ref]/assets/[asset]/[tab].js
+++ b/services/web-app/pages/libraries/[host]/[org]/[repo]/[library]/[ref]/assets/[asset]/[tab].js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/pages/libraries/[host]/[org]/[repo]/[library]/[ref]/assets/[asset]/[tab].module.scss
+++ b/services/web-app/pages/libraries/[host]/[org]/[repo]/[library]/[ref]/assets/[asset]/[tab].module.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/pages/libraries/[host]/[org]/[repo]/[library]/[ref]/assets/[asset]/index.js
+++ b/services/web-app/pages/libraries/[host]/[org]/[repo]/[library]/[ref]/assets/[asset]/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/pages/libraries/[host]/[org]/[repo]/[library]/[ref]/assets/[asset]/index.module.scss
+++ b/services/web-app/pages/libraries/[host]/[org]/[repo]/[library]/[ref]/assets/[asset]/index.module.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/pages/libraries/[host]/[org]/[repo]/[library]/[ref]/assets/index.js
+++ b/services/web-app/pages/libraries/[host]/[org]/[repo]/[library]/[ref]/assets/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/pages/libraries/[host]/[org]/[repo]/[library]/[ref]/assets/index.module.scss
+++ b/services/web-app/pages/libraries/[host]/[org]/[repo]/[library]/[ref]/assets/index.module.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/pages/libraries/[host]/[org]/[repo]/[library]/[ref]/design-kits.js
+++ b/services/web-app/pages/libraries/[host]/[org]/[repo]/[library]/[ref]/design-kits.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/pages/libraries/[host]/[org]/[repo]/[library]/[ref]/index.js
+++ b/services/web-app/pages/libraries/[host]/[org]/[repo]/[library]/[ref]/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/pages/libraries/[host]/[org]/[repo]/[library]/[ref]/index.module.scss
+++ b/services/web-app/pages/libraries/[host]/[org]/[repo]/[library]/[ref]/index.module.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/pages/libraries/[host]/[org]/[repo]/[library]/[ref]/pages/[...page].js
+++ b/services/web-app/pages/libraries/[host]/[org]/[repo]/[library]/[ref]/pages/[...page].js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/pages/libraries/index.js
+++ b/services/web-app/pages/libraries/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/pages/libraries/index.module.scss
+++ b/services/web-app/pages/libraries/index.module.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/pages/pages.module.scss
+++ b/services/web-app/pages/pages.module.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/pages/samples/protectedPageWithSSR.js
+++ b/services/web-app/pages/samples/protectedPageWithSSR.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/pages/samples/protectedPageWithSSRDynamicAuth.js
+++ b/services/web-app/pages/samples/protectedPageWithSSRDynamicAuth.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/pages/samples/protectedStaticPage.js
+++ b/services/web-app/pages/samples/protectedStaticPage.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/pages/samples/remote-mdx-test.js
+++ b/services/web-app/pages/samples/remote-mdx-test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/pages/standards.js
+++ b/services/web-app/pages/standards.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/proxy-server.mjs
+++ b/services/web-app/proxy-server.mjs
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/scripts/create-local-certificates.sh
+++ b/services/web-app/scripts/create-local-certificates.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright IBM Corp. 2021, 2021
+# Copyright IBM Corp. 2021, 2023
 #
 # This source code is licensed under the Apache-2.0 license found in the
 # LICENSE file in the root directory of this source tree.

--- a/services/web-app/stories/components/back-top-top.stories.js
+++ b/services/web-app/stories/components/back-top-top.stories.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/stories/components/color-token-table.stories.js
+++ b/services/web-app/stories/components/color-token-table.stories.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/stories/components/framework-icon.stories.js
+++ b/services/web-app/stories/components/framework-icon.stories.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/stories/components/glossary.stories.js
+++ b/services/web-app/stories/components/glossary.stories.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/stories/components/status-indicator-table.stories.js
+++ b/services/web-app/stories/components/status-indicator-table.stories.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/stories/components/type-weight.stories.js
+++ b/services/web-app/stories/components/type-weight.stories.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/stories/components/typeset-style.stories.js
+++ b/services/web-app/stories/components/typeset-style.stories.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/stories/mdx/color-block.stories.js
+++ b/services/web-app/stories/mdx/color-block.stories.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/stories/mdx/color-grid.stories.js
+++ b/services/web-app/stories/mdx/color-grid.stories.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/stories/mdx/do-dont.stories.js
+++ b/services/web-app/stories/mdx/do-dont.stories.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/stories/mdx/mdx-icon.stories.js
+++ b/services/web-app/stories/mdx/mdx-icon.stories.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/stories/mdx/profile.stories.js
+++ b/services/web-app/stories/mdx/profile.stories.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/stories/pages/404.stories.js
+++ b/services/web-app/stories/pages/404.stories.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/stories/pages/homepage.stories.js
+++ b/services/web-app/stories/pages/homepage.stories.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/styles/_base.scss
+++ b/services/web-app/styles/_base.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/styles/_mixins.scss
+++ b/services/web-app/styles/_mixins.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/styles/_prism-theme.scss
+++ b/services/web-app/styles/_prism-theme.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/styles/_variables.scss
+++ b/services/web-app/styles/_variables.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/styles/styles.scss
+++ b/services/web-app/styles/styles.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/styles/vendor/_carbon.scss
+++ b/services/web-app/styles/vendor/_carbon.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/styles/vendor/_overrides.scss
+++ b/services/web-app/styles/vendor/_overrides.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/styles/vendor/index.scss
+++ b/services/web-app/styles/vendor/index.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/typedefs.js
+++ b/services/web-app/typedefs.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/types.js
+++ b/services/web-app/types.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/utils/array.js
+++ b/services/web-app/utils/array.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/utils/auth-checkers/isValidIbmUser.js
+++ b/services/web-app/utils/auth-checkers/isValidIbmUser.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/utils/date.js
+++ b/services/web-app/utils/date.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/utils/getPropsWithAuth.js
+++ b/services/web-app/utils/getPropsWithAuth.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/utils/mdx-url-resolver.js
+++ b/services/web-app/utils/mdx-url-resolver.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/utils/mdx-wrapper-plugin.mjs
+++ b/services/web-app/utils/mdx-wrapper-plugin.mjs
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/utils/mdx.js
+++ b/services/web-app/utils/mdx.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/utils/rehype-meta-as-attributes.mjs
+++ b/services/web-app/utils/rehype-meta-as-attributes.mjs
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/utils/resources.js
+++ b/services/web-app/utils/resources.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/utils/retrieveUser.js
+++ b/services/web-app/utils/retrieveUser.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/utils/schema.js
+++ b/services/web-app/utils/schema.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/utils/sendLocalRequest.js
+++ b/services/web-app/utils/sendLocalRequest.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/utils/slug.js
+++ b/services/web-app/utils/slug.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/utils/string.js
+++ b/services/web-app/utils/string.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/utils/tree.js
+++ b/services/web-app/utils/tree.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/utils/url.js
+++ b/services/web-app/utils/url.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/utils/use-column-count.js
+++ b/services/web-app/utils/use-column-count.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/utils/use-event-listener.js
+++ b/services/web-app/utils/use-event-listener.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/utils/use-focus.js
+++ b/services/web-app/utils/use-focus.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/utils/use-id.js
+++ b/services/web-app/utils/use-id.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/utils/use-intersection-observer.js
+++ b/services/web-app/utils/use-intersection-observer.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/utils/use-local-state.js
+++ b/services/web-app/utils/use-local-state.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/utils/use-match-media.js
+++ b/services/web-app/utils/use-match-media.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/utils/use-on-key.js
+++ b/services/web-app/utils/use-on-key.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/utils/use-outside-click.js
+++ b/services/web-app/utils/use-outside-click.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/utils/use-previous.js
+++ b/services/web-app/utils/use-previous.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/utils/use-query-state.js
+++ b/services/web-app/utils/use-query-state.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/services/web-app/utils/use-sticky.js
+++ b/services/web-app/utils/use-sticky.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.


### PR DESCRIPTION
Our copyright comments follow the format "year this file was created", "current year". That means once I year we need to do some find-all-replace to update the last year in all source code copyright comments to end in `, 2023`. 

#### Changelog

**New**

- N/A

**Changed**

- `.copyright.js`
- All source files

**Removed**

- N/A

#### Testing / reviewing

Make sure linting continues to work. I did a test commit on this branch after this `--no-verify` commit and that worked fine.