### PR TITLE
fix(web-app): update develop migration guide

### DIFF
--- a/services/web-app/pages/migrating/guide/develop.mdx
+++ b/services/web-app/pages/migrating/guide/develop.mdx
@@ -56,9 +56,7 @@ they will only be re–exports of `@carbon/styles` and `@carbon/react` respectiv
 
 ## carbon-components-react
 
-Starting in v11, the React components for Carbon live in the `@carbon/react` package. Alternatively,
-you can continue to use `carbon-components` as it re–exports components from the `@carbon/react`
-package.
+Starting in v11, the React components for Carbon live in the `@carbon/react` package.
 
 The `@carbon/react` package also includes the styles for Carbon along with icons.
 


### PR DESCRIPTION
Closes #1595

#### Testing / reviewing

http://localhost:3000/migrating/guide/develop should have parity with https://carbondesignsystem.com/migrating/guide/develop