### PR TITLE
fix(web-app): Content Sync - update carbon roadmap link and icon

### DIFF
--- a/services/web-app/pages/about-carbon/releases.mdx
+++ b/services/web-app/pages/about-carbon/releases.mdx
@@ -26,9 +26,9 @@ future.
   <Column md={4} lg={4}>
     <ResourceCard
       subTitle="Roadmap"
-      href="https://app.zenhub.com/workspaces/system-squad-593830641344b813db10934d/roadmap"
+      href="https://github.com/orgs/carbon-design-system/projects/51/views/1"
     >
-      <MdxIcon name="zenhub" />
+      <MdxIcon name="github" />
     </ResourceCard>
   </Column>
 </Grid>


### PR DESCRIPTION
Closes #1609 
 
Content Sync: use github projects link instead of zenhub for carbon roadmap

#### Changelog

**Changed**

- services/web-app/pages/about-carbon/releases.mdx: update roadmap link and icon

#### Testing / reviewing

https://carbondesignsystem.com/all-about-carbon/releases/#resources vs http://localhost:3000/about-carbon/releases#resources
