### PR TITLE
deps: move @carbon/react and @carbon/styles back to 1.27

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,8 @@
         "services/web-app"
       ],
       "dependencies": {
-        "@carbon/react": "^1.28.0",
+        "@carbon/react": "1.27.0",
+        "@carbon/styles": "1.27.0",
         "@nestjs/cli": "^9.4.2",
         "@nestjs/common": "^9.4.0",
         "@nestjs/core": "^9.4.0",
@@ -3866,16 +3867,16 @@
       }
     },
     "node_modules/@carbon/react": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/@carbon/react/-/react-1.28.0.tgz",
-      "integrity": "sha512-idgdWGMiK8DhH8X4djVN6JZrltPkIUdTziLC1KxTRNQyHS6V29qHqlq9uElXlYwvyGrjBEriXC+9uOsi/O4ONg==",
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/@carbon/react/-/react-1.27.0.tgz",
+      "integrity": "sha512-kzXmBsbiDexOzq7ljeBKjW0ym6u1uAkU5EMOs08kF/qCVo4hx3GELmmm2F4AsKG/ltdt4JQo9VlVrnr+aobFBQ==",
       "hasInstallScript": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@carbon/feature-flags": "^0.13.0",
-        "@carbon/icons-react": "^11.19.0",
+        "@carbon/icons-react": "^11.18.0",
         "@carbon/layout": "^11.13.0",
-        "@carbon/styles": "^1.28.0",
+        "@carbon/styles": "^1.27.0",
         "@carbon/telemetry": "0.1.0",
         "classnames": "2.3.2",
         "copy-to-clipboard": "^3.3.1",
@@ -3900,9 +3901,9 @@
       }
     },
     "node_modules/@carbon/styles": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/@carbon/styles/-/styles-1.28.0.tgz",
-      "integrity": "sha512-QID/cHlKEUsFiEjc40/QbJ48wC0o4xs3JEcGMC2Do+TXaMmqGdzQ8u07lQuRY9FHLaUPEo/Mh2xQ59Ublnbz0g==",
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/@carbon/styles/-/styles-1.27.0.tgz",
+      "integrity": "sha512-a+4lclMjL5Ipo7yCmkymdh3opqRmbeYeiUNfeFZOjPjvjEn3PgMsKWn1FNZszaiT/6eySJThvUtJcSXwFac1jg==",
       "dependencies": {
         "@carbon/colors": "^11.14.0",
         "@carbon/feature-flags": "^0.13.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
     "test": "c8 --config=.c8rc.json npm --workspaces --if-present run test"
   },
   "dependencies": {
-    "@carbon/react": "^1.28.0",
+    "@carbon/react": "1.27.0",
+    "@carbon/styles": "1.27.0",
     "@nestjs/cli": "^9.4.2",
     "@nestjs/common": "^9.4.0",
     "@nestjs/core": "^9.4.0",


### PR DESCRIPTION
Revert Carbon version back to 1.27 until https://github.com/carbon-design-system/carbon/issues/13725 is fixed.

Check that search box styles are correct. 
![Screenshot 2023-05-04 at 9 16 53 AM](https://user-images.githubusercontent.com/2753488/236235061-d269d9e3-b23f-4475-8844-29cf27009a5d.png)
